### PR TITLE
feat: add hermes as a first-class ACP provider

### DIFF
--- a/zenith/src/zenith_harness/acp_runner.py
+++ b/zenith/src/zenith_harness/acp_runner.py
@@ -95,14 +95,18 @@ def _augment_acp_command(command: str, provider) -> str:
     For codex-acp this is the no-ask, no-sandbox combo — equivalent to
     `codex --dangerously-bypass-approvals-and-sandbox`, which codex-acp
     does not expose as a flag but accepts via `-c` overrides.
+
+    For hermes the command is passed through unchanged.
     """
-    if getattr(provider, "name", None) == "codex":
+    name = getattr(provider, "name", None)
+    if name == "codex":
         return (
             command
             + ' -c sandbox_mode="danger-full-access"'
             + ' -c approval_policy="never"'
             + ' -c model_reasoning_effort="xhigh"'
         )
+    # hermes: no-op
     return command
 
 
@@ -113,12 +117,16 @@ def _acp_subprocess_env(provider) -> dict[str, str]:
     `/usr/bin/env node`, and pass sandbox-disable hints through env. The
     command line also receives `sandbox_mode="danger-full-access"` in
     `_augment_acp_command`.
+
+    For hermes the env is passed through unchanged.
     """
     env = os.environ.copy()
-    if getattr(provider, "name", None) == "codex":
+    name = getattr(provider, "name", None)
+    if name == "codex":
         # Env-var hints — harmless if codex ignores them.
         env["CODEX_SANDBOX"] = "danger-full-access"
         env["CODEX_DISABLE_SANDBOX"] = "1"
+    # hermes: no special env needed
     return env
 
 

--- a/zenith/src/zenith_harness/providers.py
+++ b/zenith/src/zenith_harness/providers.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-ProviderName = Literal["claude", "codex"]
+ProviderName = Literal["claude", "codex", "hermes"]
 ConfigFormat = Literal["mcp_json", "codex_config"]
 
 ORCHESTRATOR_PROVIDER_NAMES: tuple[ProviderName, ...] = (
     "claude",
     "codex",
+    "hermes",
 )
 WORKER_PROVIDER_NAMES: tuple[ProviderName, ...] = (
     "claude",
     "codex",
+    "hermes",
 )
 
 
@@ -137,6 +139,17 @@ PROVIDERS: dict[ProviderName, ProviderDefinition] = {
         agent_output_dir=".codex/agents",
         orchestrator_prompt_output_path=".codex/orchestrator_prompt.md",
         acp_supports_system_prompt=False,
+    ),
+    "hermes": ProviderDefinition(
+        name="hermes",
+        skill_dirs=(".hermes/skills", ".agents/skills"),
+        skill_alias_dirs=(".hermes/skills", ".agents/skills"),
+        config_format="mcp_json",
+        default_worker_acp_command="hermes acp",
+        agent_output_dir=".hermes/agents",
+        orchestrator_prompt_output_path=".hermes/orchestrator_prompt.md",
+        acp_supports_system_prompt=True,
+        acp_runtime_mode=None,
     ),
 }
 


### PR DESCRIPTION
## Summary

Wire hermes (hermes-agent) as a worker/orchestrator provider alongside claude and codex. Hermes speaks the same ACP JSON-RPC over stdio protocol as claude-agent-acp/codex-acp, so the integration is minimal.

## Changes

**providers.py**
- Add 'hermes' to `ProviderName`, `ORCHESTRATOR_PROVIDER_NAMES`, `WORKER_PROVIDER_NAMES`
- Add `ProviderDefinition("hermes", ...)` with:
  - `default_worker_acp_command="hermes acp"`
  - `config_format="mcp_json"`
  - `acp_runtime_mode=None` (so `_ensure_claude_settings` is a no-op)
  - `skill_dirs=(".hermes/skills", ".agents/skills")`

**acp_runner.py**
- `_augment_acp_command`: hermes passes through unchanged (codex gets sandbox/approval overrides)
- `_acp_subprocess_env`: hermes passes through unchanged (codex gets CODEX_SANDBOX env vars)

## Usage

```bash
# hermes as orchestrator + worker
zenith init --agent hermes --workspace-dir /path/to/repo

# hermes with a specific profile
zenith init --agent hermes \
  --worker-acp-command "hermes --profile myprofile acp" \
  --workspace-dir /path/to/repo
```

## Test results

198 passed, 7 skipped, 1 pre-existing failure (test string drift in `test_codex_writes_codex_config` — unrelated to this change).
