### PR TITLE
fix(acp): drain terminal-reviewer stderr so it can't stall before submit_terminal_review

### DIFF
--- a/zenith/src/zenith_harness/acp_runner.py
+++ b/zenith/src/zenith_harness/acp_runner.py
@@ -788,6 +788,13 @@ class ACPNodeRunner:
             process, workspace_dir, session_update_handler=tracker.handle_session_update
         )
         await client.start()
+        # Drain the reviewer subprocess's stderr continuously. Without this the
+        # OS stderr pipe (~64 KB) fills on a chatty reviewer (it reads the whole
+        # workspace and emits many tool calls), the child blocks on its stderr
+        # write, the ACP/stdout channel stalls, and the reviewer can never call
+        # submit_terminal_review -> spurious "terminal reviewer crashed". run_node
+        # already does this for workers; run_terminal_review omitted it.
+        stderr_task = asyncio.create_task(_drain_stream_chunks(process.stderr))
         try:
             await client.send_request(
                 "initialize",
@@ -817,6 +824,10 @@ class ACPNodeRunner:
             )
             await self._poll_attempt_file(report_path, timeout=2.0)
         finally:
+            try:
+                stderr_task.cancel()
+            except Exception:  # noqa: BLE001
+                pass
             await tracker.flush()
             if process.returncode is None:
                 try:


### PR DESCRIPTION
## Problem

`ACPNodeRunner.run_terminal_review` spawns the reviewer subprocess with `stderr=PIPE` but **never drains it** — unlike `run_node` (workers), which runs `asyncio.create_task(_drain_stream_chunks(process.stderr))`.

A terminal reviewer that inspects a large workspace and emits many tool calls writes enough to stderr to fill the ~64 KB OS pipe buffer. The child then **blocks on the stderr write**, which stalls the ACP/stdout channel, so the reviewer can never call `submit_terminal_review`. The runtime then records a spurious `Terminal reviewer crashed: exited without calling submit_terminal_review` and fails an otherwise-complete mission.

Observed: 0/3 live `end_mission` runs on a large workspace, all crashing this way, while an out-of-band reviewer whose stderr happened to stay under the buffer submitted cleanly.

## Fix

Mirror `run_node`: drain `process.stderr` via a background task for the duration of the reviewer session and cancel it in `finally`. Minimal, isolated to `run_terminal_review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)