### PR TITLE
fix(validation): reject contract-less plans at submit_plan

### DIFF
--- a/zenith/src/zenith_harness/server.py
+++ b/zenith/src/zenith_harness/server.py
@@ -146,9 +146,9 @@ def _register_orchestrator_tools(mcp: FastMCP, controller: ProjectController) ->
         description=(
             "Submit the current mission's contract-backed task list. Before calling, "
             "write every targeted contract/<id>.md file under the mission contract "
-            "directory. Runtime validates task shape, depends_on resolution, "
-            "acyclicity, coverage (each assertion has exactly one non-superseded work "
-            "task). On success state becomes "
+            "directory. Runtime validates a non-empty contract, task shape, "
+            "depends_on resolution, acyclicity, coverage (each assertion has exactly "
+            "one non-superseded work task). On success state becomes "
             "mission_running; call advance_project to dispatch work."
         ),
     )

--- a/zenith/src/zenith_harness/task_validation.py
+++ b/zenith/src/zenith_harness/task_validation.py
@@ -220,6 +220,17 @@ def validate_task_list_submission(
     tl: TaskList,
 ) -> list[ValidationError]:
     """Run all submit-time checks. Stops at the first failing check group."""
+    if not contract_ids:
+        # Without this, a plan of targetless work tasks over an empty
+        # contract/ dir satisfies every later check vacuously and the
+        # mission runs with no assertions, validators, or gates.
+        return [
+            ValidationError(
+                "empty_contract",
+                "mission has no contract assertions; write contract/<ID>.md "
+                "files before submit_plan",
+            )
+        ]
     if not tl.tasks:
         return [ValidationError("empty_task_list", "submit_plan requires at least one task")]
     errs = check_task_ids(tl)

--- a/zenith/tests/test_coordinator.py
+++ b/zenith/tests/test_coordinator.py
@@ -383,6 +383,30 @@ class TestValidatorDissentFailsGate:
         assert "missing: VAL-001" in report
 
 
+class TestSubmitPlanValidation:
+    def test_contract_less_plan_rejected(
+        self, config: HarnessConfig, workspace: Path
+    ) -> None:
+        controller = ProjectController(
+            config,
+            MockDispatcher(
+                lambda req: WorkHandoff(node_id=req.task.id, done=True, report="ok")
+            ),
+            MockTerminalReviewer(TerminalReviewHandoff(done=True, report="")),
+        )
+        # Seed the project but author no contract assertion files.
+        controller.start_project("Brief.", str(workspace))
+        pid = controller.store.list_projects()[0].id
+
+        with pytest.raises(ToolError) as exc:
+            controller.submit_plan(pid, TaskList(tasks=[_task("w1", "work", [])]))
+        assert exc.value.code == "invalid_task_list"
+        assert any("empty_contract" in str(d) for d in (exc.value.details or []))
+
+        state = controller.store.load_state(pid)
+        assert state is not None and state.state == "mission_planning"
+
+
 class TestDecideAttentionValidation:
     def test_atomic_rejection(
         self, config: HarnessConfig, workspace: Path

--- a/zenith/tests/test_task_validation.py
+++ b/zenith/tests/test_task_validation.py
@@ -193,6 +193,19 @@ class TestValidateSubmission:
         errs = validate_task_list_submission({"X"}, tl)
         assert errs and errs[0].code == "empty_task_list"
 
+    def test_empty_contract_rejected(self) -> None:
+        # Targetless work tasks over an empty contract pass every other
+        # check vacuously; the contract itself must be non-empty.
+        tl = TaskList(tasks=[_task("w1", "work", [])])
+        errs = validate_task_list_submission(set(), tl)
+        assert errs and errs[0].code == "empty_contract"
+
+    def test_empty_contract_reported_before_empty_task_list(self) -> None:
+        # Contract authoring precedes task authoring; point at the
+        # earliest missing artifact first.
+        errs = validate_task_list_submission(set(), TaskList(tasks=[]))
+        assert errs and errs[0].code == "empty_contract"
+
     def test_validator_requires_targets(self) -> None:
         tl = TaskList(tasks=[
             _task("v1", "validate", []),


### PR DESCRIPTION
## The hole

`submit_plan` currently accepts a plan with **zero contract assertions**. This degenerate plan passes every submit-time check today:

```json
{"tasks": [{"id": "w1", "type": "work", "body": "do the mission", "targets": [], "skill": "s"}]}
```

with `missions/<mid>/contract/` empty. Each guard is individually correct but vacuous in combination:

- `check_coverage` iterates over contract ids — with none, there is nothing to be uncovered.
- `work` tasks may legitimately have empty `targets` (setup/discovery/integration nodes), so shape checks pass.
- The `contract_dir_missing` parse error can never fire from `submit_plan`, because the controller calls `ensure_contract_dir()` first, which creates the (empty) directory.

Downstream, nothing recovers: the coordinator backfills contract state from the same empty directory, no validator or gate can exist (both require targets that must resolve to assertions), and `close_mission` checks only for runnable work before going straight to terminal review. The mission runs as a plain todo list — no assertions, no independent validators, no dissent-blocking gates — and the mission-blind terminal reviewer becomes the *only* line of defense for the property the whole runtime exists to enforce structurally.

The orchestrator system prompt does mandate contract authoring before `submit_plan`, but that is prompt discipline, not a runtime invariant — and Zenith is distributed for arbitrary host agents, not just the bundled prompt. This PR moves the smallest load-bearing slice of that prose into code, in the same spirit as the tech report's harness ladder (each rung turns an observed prompt-level failure mode into a mechanism).

## The fix

One new first check in `validate_task_list_submission`:

- `empty_contract` — rejected when no contract assertion files exist for the mission.
- Reported before `empty_task_list`, since contract authoring precedes task authoring; the error text tells the orchestrator exactly what to do (`write contract/<ID>.md files before submit_plan`).
- The `submit_plan` tool description now names the invariant, so host orchestrators see it in the tool schema too.

The patch path is deliberately untouched: `apply_patch` re-runs the individual checks and patches can only *add* assertions, so a mission that entered running state can never regress to an empty contract.

## Tests

- `test_empty_contract_rejected` — the exact degenerate plan above, red on `main` (returns `[]`), green here.
- `test_empty_contract_reported_before_empty_task_list` — pins the error-ordering choice.
- `test_contract_less_plan_rejected` — controller-level: `submit_plan` raises `invalid_task_list` with the `empty_contract` detail and the project stays in `mission_planning`.

`ruff check .`, `mypy src`, and `pytest -q` all pass (199 passed, 7 ACP smoke tests skipped, on Linux/py3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
