### PR TITLE
fix(server): hold per-project wave lock in worker thread, not async request

### DIFF
--- a/zenith/src/zenith_harness/acp_runner.py
+++ b/zenith/src/zenith_harness/acp_runner.py
@@ -21,6 +21,10 @@ from .models import (
     ValidateHandoff,
     WorkHandoff,
 )
+from .runtime_identity import (
+    RuntimeIdentityRegistration,
+    _register_node_runtime_identity,
+)
 from .storage import (
     ProjectStore,
     atomic_write_json,
@@ -34,6 +38,8 @@ SUBPROCESS_STREAM_LIMIT = int(
         str(8 * 1024 * 1024),
     )
 )
+HANDOFF_REPAIR_TIMEOUT_SECONDS = 30.0
+ACP_STDERR_TAIL_BYTES = 64 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +116,9 @@ def _augment_acp_command(command: str, provider) -> str:
     return command
 
 
-def _acp_subprocess_env(provider) -> dict[str, str]:
+def _acp_subprocess_env(
+    provider, *, runtime_identity_environment: dict[str, str] | None = None
+) -> dict[str, str]:
     """Build the env handed to an ACP-agent subprocess.
 
     For codex we preserve PATH so node-based ACP adapters can launch via
@@ -121,11 +129,18 @@ def _acp_subprocess_env(provider) -> dict[str, str]:
     For hermes the env is passed through unchanged.
     """
     env = os.environ.copy()
+    for key in tuple(env):
+        if key.startswith("SELF_IMPROVEMENT_ZENITH_AUTHORITY_") or key == (
+            "SELF_IMPROVEMENT_ZENITH_ISSUER_STATE"
+        ):
+            env.pop(key, None)
     name = getattr(provider, "name", None)
     if name == "codex":
         # Env-var hints — harmless if codex ignores them.
         env["CODEX_SANDBOX"] = "danger-full-access"
         env["CODEX_DISABLE_SANDBOX"] = "1"
+    if runtime_identity_environment:
+        env.update(runtime_identity_environment)
     # hermes: no special env needed
     return env
 
@@ -177,20 +192,20 @@ async def _wait_for_process_exit(
 async def _drain_stream_chunks(stream: asyncio.StreamReader | None) -> str:
     if stream is None:
         return ""
-    chunks: list[str] = []
+    tail = bytearray()
     try:
         while True:
             chunk = await stream.read(4096)
             if not chunk:
                 break
-            text = chunk.decode("utf-8", errors="replace")
-            if text:
-                chunks.append(text)
+            tail.extend(chunk)
+            if len(tail) > ACP_STDERR_TAIL_BYTES:
+                del tail[: len(tail) - ACP_STDERR_TAIL_BYTES]
     except asyncio.CancelledError:
-        raise
+        pass
     except Exception:  # noqa: BLE001
-        return "".join(chunks)
-    return "".join(chunks)
+        pass
+    return bytes(tail).decode("utf-8", errors="replace")
 
 
 @dataclass
@@ -240,9 +255,12 @@ class ACPProgressTracker:
         if not msg or self.callback is None or msg == self.last_emitted:
             return
         self.last_emitted = msg
-        out = self.callback(f"Agent: {msg}")
-        if inspect.isawaitable(out):
-            await out
+        try:
+            out = self.callback(f"Agent: {msg}")
+            if inspect.isawaitable(out):
+                await out
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Progress callback failed: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -281,10 +299,15 @@ class ACPClient:
         self._pending[rid] = future
         try:
             await self._write(msg)
+            return await future
+        except asyncio.CancelledError:
+            self._pending.pop(rid, None)
+            if not future.done():
+                future.cancel()
+            raise
         except Exception:
             self._pending.pop(rid, None)
             raise
-        return await future
 
     async def _write(self, msg: dict[str, Any]) -> None:
         assert self._process.stdin is not None
@@ -540,6 +563,31 @@ class ACPNodeRunner:
     config: HarnessConfig
     loader: AssetLoader
 
+    def _register_runtime_identity(
+        self,
+        *,
+        store: ProjectStore,
+        project_id: str,
+        mission_id: str,
+        task: Task,
+        spawn_ts: str,
+        role: Literal["validator", "worker"],
+        workspace_dir: Path,
+    ) -> RuntimeIdentityRegistration:
+        role_config = self.config.for_role(role)
+        return _register_node_runtime_identity(
+            store=store,
+            project_id=project_id,
+            mission_id=mission_id,
+            task_id=task.id,
+            spawn_ts=spawn_ts,
+            executor=f"{role_config.worker_provider.name}-{role}",
+            provider=role_config.worker_provider.name,
+            task_type=task.type,
+            execution_role=role,
+            workspace_dir=workspace_dir,
+        )
+
     @staticmethod
     def _find_free_port() -> int:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -558,9 +606,7 @@ class ACPNodeRunner:
         progress_callback: ProgressCallback | None = None,
     ) -> NodeHandoff:
         """Spawn the worker MCP server + ACP agent; poll the attempt file; return the handoff."""
-        role: Literal["validator", "worker"] = (
-            "validator" if task.type == "validate" else "worker"
-        )
+        role: Literal["validator", "worker"] = "validator" if task.type == "validate" else "worker"
         role_config = self.config.for_role(role)
         acp_command = role_config.worker_acp_command or role_config.resolved_worker_acp_command
         if not acp_command:
@@ -569,7 +615,9 @@ class ACPNodeRunner:
             )
         acp_command = _augment_acp_command(acp_command, role_config.worker_provider)
 
-        workspace_dir = str(Path(cwd).expanduser().resolve() if cwd else store.workspace_dir(project_id))
+        workspace_dir = str(
+            Path(cwd).expanduser().resolve() if cwd else store.workspace_dir(project_id)
+        )
         project_bucket = str(store.zenith_dir(project_id))
         handoff_path = store.attempt_path(project_id, mission_id, spawn_ts, task.id)
         handoff_path.parent.mkdir(parents=True, exist_ok=True)
@@ -600,6 +648,45 @@ class ACPNodeRunner:
             return self._synthesize_missing_handoff(
                 task, summary="Worker MCP server failed to start"
             )
+        except asyncio.CancelledError:
+            if mcp_process.returncode is None:
+                mcp_process.terminate()
+            await asyncio.shield(_close_subprocess(mcp_process, timeout=5))
+            raise
+
+        async def _cleanup_setup_failure(
+            *,
+            registration: RuntimeIdentityRegistration | None = None,
+            process: asyncio.subprocess.Process | None = None,
+            client: ACPClient | None = None,
+        ) -> None:
+            if client is not None:
+                try:
+                    await asyncio.wait_for(
+                        client.cleanup(close_main_process=False),
+                        timeout=10,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Setup ACP client cleanup failed: %s", exc)
+            if process is not None:
+                try:
+                    await _close_subprocess(process, timeout=5)
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Setup ACP process cleanup failed: %s", exc)
+            if registration is not None:
+                try:
+                    registration.close()
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Setup runtime identity cleanup failed: %s", exc)
+            if mcp_process.returncode is None:
+                try:
+                    mcp_process.terminate()
+                except OSError:
+                    pass
+            try:
+                await _close_subprocess(mcp_process, timeout=5)
+            except BaseException as exc:  # noqa: BLE001
+                logger.warning("Setup worker MCP cleanup failed: %s", exc)
 
         worker_mcp_cfg = {
             "type": "http",
@@ -610,32 +697,71 @@ class ACPNodeRunner:
         }
 
         # 2) Render the prompt (system + template merged into one first message).
-        first_message = self._render_prompts(
-            task=task,
-            mission_id=mission_id,
-            project_bucket=project_bucket,
-            workspace_dir=workspace_dir,
-            store=store,
-            project_id=project_id,
-        )
+        identity_registration: RuntimeIdentityRegistration | None = None
+        try:
+            first_message = self._render_prompts(
+                task=task,
+                mission_id=mission_id,
+                project_bucket=project_bucket,
+                workspace_dir=workspace_dir,
+                store=store,
+                project_id=project_id,
+            )
 
-        # 3) Spawn the ACP agent.
-        process = await asyncio.create_subprocess_shell(
-            acp_command,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=workspace_dir,
-            env=_acp_subprocess_env(role_config.worker_provider),
-            limit=SUBPROCESS_STREAM_LIMIT,
-        )
+            # 3) Spawn the ACP agent.
+            identity_registration = self._register_runtime_identity(
+                store=store,
+                project_id=project_id,
+                mission_id=mission_id,
+                task=task,
+                spawn_ts=spawn_ts,
+                role=role,
+                workspace_dir=Path(workspace_dir),
+            )
+        except BaseException:
+            await asyncio.shield(_cleanup_setup_failure())
+            raise
+        if identity_registration.endpoint is None or identity_registration.capability is None:
+            await asyncio.shield(_cleanup_setup_failure(registration=identity_registration))
+            return self._synthesize_missing_handoff(
+                task,
+                summary=(
+                    f"Runtime identity registration failed: {identity_registration.reason_code}"
+                ),
+            )
+        try:
+            process = await asyncio.create_subprocess_shell(
+                acp_command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=workspace_dir,
+                env=_acp_subprocess_env(
+                    role_config.worker_provider,
+                    runtime_identity_environment=identity_registration.environment(),
+                ),
+                limit=SUBPROCESS_STREAM_LIMIT,
+            )
+        except BaseException:
+            await asyncio.shield(_cleanup_setup_failure(registration=identity_registration))
+            raise
         progress_tracker = ACPProgressTracker(callback=progress_callback)
         client = ACPClient(
             process,
             workspace_dir,
             session_update_handler=progress_tracker.handle_session_update,
         )
-        await client.start()
+        try:
+            await client.start()
+        except BaseException:
+            await asyncio.shield(
+                _cleanup_setup_failure(
+                    registration=identity_registration,
+                    process=process,
+                    client=client,
+                )
+            )
+            raise
         prompt_stop_reason: str | None = None
         session_error: str | None = None
         worker_exit_code: int | None = None
@@ -673,36 +799,104 @@ class ACPNodeRunner:
                     prompt_stop_reason = sr
 
             # 4) Give the worker MCP server a short grace period to flush.
-            await self._poll_attempt_file(handoff_path, timeout=2.0)
+            handoff_written = await self._poll_attempt_file(handoff_path, timeout=2.0)
+            if task.type == "validate" and not handoff_written and prompt_stop_reason == "end_turn":
+                # Some ACP agents finish with a prose response despite the
+                # mandatory end_node instruction.  Keep the same session and
+                # give it one bounded protocol-repair turn so completed work is
+                # not discarded as a synthetic empty handoff.
+                try:
+                    repair_result = await asyncio.wait_for(
+                        client.send_request(
+                            "session/prompt",
+                            {
+                                "prompt": [
+                                    {
+                                        "type": "text",
+                                        "text": (
+                                            "Protocol repair: the previous turn ended "
+                                            "without calling the required zenith-worker "
+                                            "end_node tool. Do not redo, extend, or change "
+                                            "the completed validation. Call end_node exactly "
+                                            "once now using the result and evidence you "
+                                            "already gathered. Include one items entry for "
+                                            "every assigned target. If you cannot provide the "
+                                            "required handoff, call end_node with done=false "
+                                            "and request_attention=true. Do not return prose "
+                                            "before the tool call."
+                                        ),
+                                    }
+                                ],
+                                "sessionId": session_id,
+                            },
+                        ),
+                        timeout=HANDOFF_REPAIR_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError as exc:
+                    raise TimeoutError("validator end_node protocol repair timed out") from exc
+                if isinstance(repair_result, dict):
+                    repair_stop_reason = repair_result.get("stopReason")
+                    if isinstance(repair_stop_reason, str):
+                        prompt_stop_reason = repair_stop_reason
+                await self._poll_attempt_file(handoff_path, timeout=2.0)
         except Exception as exc:  # noqa: BLE001
             session_error = str(exc)
             logger.error("ACP session failed for node %s: %s", task.id, exc)
         finally:
-            await progress_tracker.flush()
-            if process.returncode is None:
+
+            async def _cleanup() -> None:
+                nonlocal worker_exit_code, worker_stderr
                 try:
-                    await asyncio.wait_for(process.wait(), timeout=0.5)
+                    await asyncio.wait_for(progress_tracker.flush(), timeout=5)
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Progress flush cleanup failed: %s", exc)
+                try:
+                    await asyncio.wait_for(
+                        client.cleanup(close_main_process=False),
+                        timeout=10,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("ACP client cleanup failed: %s", exc)
+                try:
+                    await _close_subprocess(process, timeout=5)
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("ACP process cleanup failed: %s", exc)
+                worker_exit_code = process.returncode
+                try:
+                    worker_stderr = _truncate_text(
+                        await asyncio.wait_for(stderr_task, timeout=1),
+                        limit=2000,
+                    )
                 except asyncio.TimeoutError:
+                    stderr_task.cancel()
                     try:
-                        process.terminate()
+                        worker_stderr = _truncate_text(
+                            await stderr_task,
+                            limit=2000,
+                        )
+                    except BaseException:  # noqa: BLE001
+                        worker_stderr = ""
+                except BaseException:  # noqa: BLE001
+                    worker_stderr = ""
+                if mcp_process.returncode is None:
+                    try:
+                        mcp_process.terminate()
                     except OSError:
                         pass
-            await _wait_for_process_exit(process, timeout=5)
-            worker_exit_code = process.returncode
-            try:
-                worker_stderr = _truncate_text(
-                    await asyncio.wait_for(stderr_task, timeout=0.5), limit=2000
-                )
-            except (asyncio.TimeoutError, Exception):
-                worker_stderr = ""
-            await client.cleanup(close_main_process=False)
-            await _close_subprocess(process, timeout=0)
-            if mcp_process.returncode is None:
                 try:
-                    mcp_process.terminate()
-                except OSError:
-                    pass
-            await _close_subprocess(mcp_process, timeout=5)
+                    await _close_subprocess(mcp_process, timeout=5)
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Worker MCP cleanup failed: %s", exc)
+                try:
+                    identity_registration.close()
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Runtime identity cleanup failed: %s", exc)
+
+            cleanup_task = asyncio.create_task(_cleanup())
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                await cleanup_task
 
         # 5) Parse and return.
         if handoff_path.exists():
@@ -730,8 +924,7 @@ class ACPNodeRunner:
         acp_command = role_config.worker_acp_command
         if not acp_command:
             raise RuntimeError(
-                "No ACP command for terminal reviewer. "
-                "Set ZENITH_TERMINAL_REVIEWER_ACP_COMMAND."
+                "No ACP command for terminal reviewer. Set ZENITH_TERMINAL_REVIEWER_ACP_COMMAND."
             )
         acp_command = _augment_acp_command(acp_command, role_config.worker_provider)
 
@@ -751,51 +944,87 @@ class ACPNodeRunner:
             workspace_dir=workspace_dir,
             mcp_port=mcp_port,
         )
-        try:
-            await self._wait_for_server_ready("127.0.0.1", mcp_port)
-        except TimeoutError:
+        process: asyncio.subprocess.Process | None = None
+        tracker: ACPProgressTracker | None = None
+        client: ACPClient | None = None
+        stderr_task: asyncio.Task[str] | None = None
+
+        async def _cleanup() -> None:
+            if tracker is not None:
+                try:
+                    await asyncio.wait_for(tracker.flush(), timeout=5)
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Terminal progress flush cleanup failed: %s", exc)
+            if client is not None:
+                try:
+                    await asyncio.wait_for(
+                        client.cleanup(close_main_process=False),
+                        timeout=10,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Terminal ACP client cleanup failed: %s", exc)
+            if process is not None:
+                try:
+                    await _close_subprocess(process, timeout=5)
+                except BaseException as exc:  # noqa: BLE001
+                    logger.warning("Terminal ACP process cleanup failed: %s", exc)
+            if stderr_task is not None:
+                try:
+                    await asyncio.wait_for(stderr_task, timeout=1)
+                except asyncio.TimeoutError:
+                    stderr_task.cancel()
+                    try:
+                        await stderr_task
+                    except BaseException:  # noqa: BLE001
+                        pass
+                except BaseException:  # noqa: BLE001
+                    pass
             if mcp_process.returncode is None:
-                mcp_process.terminate()
-            await _close_subprocess(mcp_process, timeout=5)
-            raise RuntimeError(
-                "Terminal reviewer MCP server failed to start; cannot run terminal review"
-            )
+                try:
+                    mcp_process.terminate()
+                except OSError:
+                    pass
+            try:
+                await _close_subprocess(mcp_process, timeout=5)
+            except BaseException as exc:  # noqa: BLE001
+                logger.warning("Terminal MCP cleanup failed: %s", exc)
 
-        worker_mcp_cfg = {
-            "type": "http",
-            "name": "zenith-terminal-reviewer",
-            "url": f"http://127.0.0.1:{mcp_port}/mcp",
-            "headers": [],
-            "env": [],
-        }
-
-        first_message = self._render_terminal_reviewer_prompts(
-            project_bucket=project_bucket,
-            workspace_dir=workspace_dir,
-        )
-
-        process = await asyncio.create_subprocess_shell(
-            acp_command,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=workspace_dir,
-            env=_acp_subprocess_env(role_config.worker_provider),
-            limit=SUBPROCESS_STREAM_LIMIT,
-        )
-        tracker = ACPProgressTracker(callback=progress_callback)
-        client = ACPClient(
-            process, workspace_dir, session_update_handler=tracker.handle_session_update
-        )
-        await client.start()
-        # Drain the reviewer subprocess's stderr continuously. Without this the
-        # OS stderr pipe (~64 KB) fills on a chatty reviewer (it reads the whole
-        # workspace and emits many tool calls), the child blocks on its stderr
-        # write, the ACP/stdout channel stalls, and the reviewer can never call
-        # submit_terminal_review -> spurious "terminal reviewer crashed". run_node
-        # already does this for workers; run_terminal_review omitted it.
-        stderr_task = asyncio.create_task(_drain_stream_chunks(process.stderr))
         try:
+            try:
+                await self._wait_for_server_ready("127.0.0.1", mcp_port)
+            except TimeoutError as exc:
+                raise RuntimeError(
+                    "Terminal reviewer MCP server failed to start; cannot run terminal review"
+                ) from exc
+
+            worker_mcp_cfg = {
+                "type": "http",
+                "name": "zenith-terminal-reviewer",
+                "url": f"http://127.0.0.1:{mcp_port}/mcp",
+                "headers": [],
+                "env": [],
+            }
+            first_message = self._render_terminal_reviewer_prompts(
+                project_bucket=project_bucket,
+                workspace_dir=workspace_dir,
+            )
+            process = await asyncio.create_subprocess_shell(
+                acp_command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=workspace_dir,
+                env=_acp_subprocess_env(role_config.worker_provider),
+                limit=SUBPROCESS_STREAM_LIMIT,
+            )
+            tracker = ACPProgressTracker(callback=progress_callback)
+            client = ACPClient(
+                process,
+                workspace_dir,
+                session_update_handler=tracker.handle_session_update,
+            )
+            await client.start()
+            stderr_task = asyncio.create_task(_drain_stream_chunks(process.stderr))
             await client.send_request(
                 "initialize",
                 {
@@ -824,25 +1053,11 @@ class ACPNodeRunner:
             )
             await self._poll_attempt_file(report_path, timeout=2.0)
         finally:
+            cleanup_task = asyncio.create_task(_cleanup())
             try:
-                stderr_task.cancel()
-            except Exception:  # noqa: BLE001
-                pass
-            await tracker.flush()
-            if process.returncode is None:
-                try:
-                    process.terminate()
-                except OSError:
-                    pass
-            await _wait_for_process_exit(process, timeout=5)
-            await client.cleanup(close_main_process=False)
-            await _close_subprocess(process, timeout=0)
-            if mcp_process.returncode is None:
-                try:
-                    mcp_process.terminate()
-                except OSError:
-                    pass
-            await _close_subprocess(mcp_process, timeout=5)
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                await cleanup_task
 
         if report_path.exists():
             return TerminalReviewHandoff.model_validate_json(report_path.read_text())
@@ -888,8 +1103,8 @@ class ACPNodeRunner:
         env["ZENITH_HANDOFF_PATH"] = handoff_path
         return await asyncio.create_subprocess_exec(
             *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
             cwd=workspace_dir,
             env=env,
             limit=SUBPROCESS_STREAM_LIMIT,
@@ -923,8 +1138,8 @@ class ACPNodeRunner:
         env["ZENITH_TERMINAL_REVIEW_PATH"] = report_path
         return await asyncio.create_subprocess_exec(
             *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
             cwd=workspace_dir,
             env=env,
             limit=SUBPROCESS_STREAM_LIMIT,
@@ -951,16 +1166,12 @@ class ACPNodeRunner:
                 return False
             await asyncio.sleep(0.1)
 
-    async def _maybe_set_mode(
-        self, client: ACPClient, session_id: str, provider
-    ) -> None:
+    async def _maybe_set_mode(self, client: ACPClient, session_id: str, provider) -> None:
         mode = getattr(provider, "acp_runtime_mode", None)
         if not mode:
             return
         try:
-            await client.send_request(
-                "session/set_mode", {"sessionId": session_id, "modeId": mode}
-            )
+            await client.send_request("session/set_mode", {"sessionId": session_id, "modeId": mode})
         except ACPError as exc:
             raise ACPError(
                 f"Failed to set ACP runtime mode {mode!r} for {provider.name}: {exc}"
@@ -1070,9 +1281,7 @@ class ACPNodeRunner:
             return ValidateHandoff.model_validate(data)
         return WorkHandoff.model_validate(data)
 
-    def _synthesize_missing_handoff(
-        self, task: Task, *, summary: str = ""
-    ) -> NodeHandoff:
+    def _synthesize_missing_handoff(self, task: Task, *, summary: str = "") -> NodeHandoff:
         report = summary or "Agent session ended without calling end_node."
         if task.type == "validate":
             return ValidateHandoff(
@@ -1196,9 +1405,7 @@ class ACPTerminalReviewer:
         self.loader = AssetLoader(config)
         self.runner = ACPNodeRunner(config=config, loader=self.loader)
 
-    def review(
-        self, project_id: str, mission_id: str, spawn_ts: str
-    ) -> TerminalReviewHandoff:
+    def review(self, project_id: str, mission_id: str, spawn_ts: str) -> TerminalReviewHandoff:
         return _run_coro_blocking(
             self.runner.run_terminal_review(
                 project_id=project_id,

--- a/zenith/src/zenith_harness/coordinator.py
+++ b/zenith/src/zenith_harness/coordinator.py
@@ -587,11 +587,11 @@ class MissionCoordinator:
         )
 
     def _upstream_validators(self, tl: TaskList, gate_id: str) -> list[str]:
-        """Transitive predecessors of `gate_id` that are validate tasks.
+        """Nearest validator frontier upstream of `gate_id`.
 
-        Patches rewrite `depends_on` in-place when they supersede/cancel,
-        so the gate's reachable chain never includes retired validators —
-        no status filtering needed here.
+        Traversal stops at each validator so a replacement validation wave does
+        not inherit dissent from the historical validators that triggered its
+        repair work.
         """
         by_id = {t.id: t for t in tl.tasks}
         gate = by_id.get(gate_id)
@@ -608,6 +608,7 @@ class MissionCoordinator:
             task = by_id[cur]
             if task.type == "validate":
                 result.append(cur)
+                continue
             stack.extend(task.depends_on)
         return result
 

--- a/zenith/src/zenith_harness/runtime_identity.py
+++ b/zenith/src/zenith_harness/runtime_identity.py
@@ -1,0 +1,599 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import socket
+import struct
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .storage import ProjectStore
+
+
+AUTHORITY_ENV_ENDPOINT = "SELF_IMPROVEMENT_ZENITH_AUTHORITY_ENDPOINT"
+AUTHORITY_ENV_CAPABILITY = "SELF_IMPROVEMENT_ZENITH_AUTHORITY_CAPABILITY"
+AUTHORITY_ENV_TOKEN = "SELF_IMPROVEMENT_ZENITH_AUTHORITY_TOKEN"
+AUTHORITY_ID = "zenith-controller-channel-v1"
+REGISTERED_RUNTIME_ROOT = Path(__file__).resolve().parents[2]
+_MAX_MESSAGE_BYTES = 64 * 1024
+_MAX_RECEIPTS = 4096
+_RECEIPT_TTL_SECONDS = 60 * 60
+_MAX_REQUESTS_PER_DISPATCH = 128
+_CONNECTION_TIMEOUT_SECONDS = 1.0
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _content_hash(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _file_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class _IdentityReceipt:
+    identity: dict[str, object]
+    runtime_receipt_hash: str
+    controller_pid: int
+    issued_monotonic: float
+    consumed: bool = False
+
+
+@dataclass(frozen=True)
+class _VerificationReceipt:
+    binding_hashes: tuple[str, ...]
+    scope: tuple[str, str, str]
+    issued_monotonic: float
+    consumed: bool = False
+
+
+class _ReceiptRegistry:
+    """Controller-owned, bounded, atomic, one-use receipt registry."""
+
+    def __init__(self) -> None:
+        self._identities: OrderedDict[str, _IdentityReceipt] = OrderedDict()
+        self._verifications: OrderedDict[str, _VerificationReceipt] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def _prune_locked(self, now: float) -> None:
+        minimum = now - _RECEIPT_TTL_SECONDS
+        for records in (self._identities, self._verifications):
+            expired = [key for key, value in records.items() if value.issued_monotonic < minimum]
+            for key in expired:
+                records.pop(key, None)
+            while len(records) >= _MAX_RECEIPTS:
+                records.popitem(last=False)
+
+    def issue_identity(
+        self,
+        *,
+        identity: dict[str, object],
+        runtime_receipt_hash: str,
+        nonce: str,
+        capability: str,
+    ) -> str:
+        now = time.monotonic()
+        receipt_hash = _content_hash(
+            {
+                "schema_version": 1,
+                "authority_id": AUTHORITY_ID,
+                "controller_pid": os.getpid(),
+                "identity_hash": _content_hash(identity),
+                "runtime_receipt_hash": runtime_receipt_hash,
+                "nonce": nonce,
+                "capability_hash": _content_hash(capability),
+                "receipt_secret": secrets.token_hex(32),
+            }
+        )
+        with self._lock:
+            self._prune_locked(now)
+            self._identities[receipt_hash] = _IdentityReceipt(
+                identity=dict(identity),
+                runtime_receipt_hash=runtime_receipt_hash,
+                controller_pid=os.getpid(),
+                issued_monotonic=now,
+            )
+        return receipt_hash
+
+    def consume_identities(
+        self,
+        identities: list[dict[str, object]],
+        *,
+        nonce: str,
+        authorizer_identity: dict[str, object] | None = None,
+        verdict_binding: tuple[str, ...] | None = None,
+    ) -> tuple[str, str | None]:
+        parsed: list[tuple[str, str, str, dict[str, object]]] = []
+        for envelope in identities:
+            attestation = envelope.get("attestation")
+            if not isinstance(attestation, dict):
+                return "REJECTED", None
+            claims = dict(envelope)
+            claims.pop("attestation", None)
+            identity_hash = _content_hash(claims)
+            receipt_hash = attestation.get("channel_receipt_hash")
+            runtime_hash = attestation.get("runtime_receipt_hash")
+            controller_pid = attestation.get("controller_pid")
+            if (
+                not isinstance(receipt_hash, str)
+                or len(receipt_hash) != 64
+                or not isinstance(runtime_hash, str)
+                or len(runtime_hash) != 64
+                or controller_pid != os.getpid()
+                or attestation.get("identity_hash") != identity_hash
+                or attestation.get("authority_id") != AUTHORITY_ID
+            ):
+                return "REJECTED", None
+            parsed.append((receipt_hash, runtime_hash, identity_hash, claims))
+        if not parsed or len({item[0] for item in parsed}) != len(parsed):
+            return "REJECTED", None
+        if verdict_binding is not None:
+            if len(parsed) != 2 or authorizer_identity is None:
+                return "REJECTED", None
+            builder = parsed[0][3]
+            verifier = parsed[1][3]
+            if (
+                builder.get("task_type") != "work"
+                or builder.get("execution_role") != "worker"
+                or verifier.get("task_type") != "validate"
+                or verifier.get("execution_role") != "validator"
+                or authorizer_identity != verifier
+                or any(
+                    builder.get(name) != verifier.get(name)
+                    for name in ("orchestrator", "project_id", "mission_id")
+                )
+                or any(
+                    builder.get(name) == verifier.get(name)
+                    for name in ("task_id", "task_attempt_id", "executor")
+                )
+                or len(verdict_binding) != 3
+            ):
+                return "REJECTED", None
+        now = time.monotonic()
+        with self._lock:
+            self._prune_locked(now)
+            records: list[_IdentityReceipt] = []
+            for receipt_hash, runtime_hash, _identity_hash, claims in parsed:
+                record = self._identities.get(receipt_hash)
+                if record is None:
+                    return "REJECTED", None
+                if record.consumed:
+                    return "REPLAY", None
+                if (
+                    record.identity != claims
+                    or record.runtime_receipt_hash != runtime_hash
+                    or record.controller_pid != os.getpid()
+                ):
+                    return "REJECTED", None
+                records.append(record)
+            for (receipt_hash, *_rest), record in zip(parsed, records, strict=True):
+                self._identities[receipt_hash] = _IdentityReceipt(
+                    identity=record.identity,
+                    runtime_receipt_hash=record.runtime_receipt_hash,
+                    controller_pid=record.controller_pid,
+                    issued_monotonic=record.issued_monotonic,
+                    consumed=True,
+                )
+            identity_hashes = tuple(item[2] for item in parsed)
+            binding_hashes = (
+                (*identity_hashes, *verdict_binding)
+                if verdict_binding is not None
+                else identity_hashes
+            )
+            scope_identity = authorizer_identity or parsed[0][3]
+            raw_scope = tuple(
+                scope_identity.get(name) for name in ("orchestrator", "project_id", "mission_id")
+            )
+            if any(not isinstance(item, str) for item in raw_scope):
+                return "REJECTED", None
+            scope = (str(raw_scope[0]), str(raw_scope[1]), str(raw_scope[2]))
+            verification_hash = _content_hash(
+                {
+                    "schema_version": 1,
+                    "authority_id": AUTHORITY_ID,
+                    "controller_pid": os.getpid(),
+                    "binding_hashes": binding_hashes,
+                    "nonce": nonce,
+                    "receipt_secret": secrets.token_hex(32),
+                }
+            )
+            self._verifications[verification_hash] = _VerificationReceipt(
+                binding_hashes=binding_hashes,
+                scope=scope,
+                issued_monotonic=now,
+            )
+        return "VERIFIED", verification_hash
+
+    def consume_verification(
+        self,
+        receipt_hash: str,
+        binding_hashes: tuple[str, ...],
+        consumer_identity: dict[str, object],
+    ) -> str:
+        now = time.monotonic()
+        with self._lock:
+            self._prune_locked(now)
+            record = self._verifications.get(receipt_hash)
+            consumer_scope = tuple(
+                consumer_identity.get(name) for name in ("orchestrator", "project_id", "mission_id")
+            )
+            if (
+                record is None
+                or record.consumed
+                or record.binding_hashes != binding_hashes
+                or consumer_scope != record.scope
+            ):
+                return "REJECTED"
+            self._verifications[receipt_hash] = _VerificationReceipt(
+                binding_hashes=record.binding_hashes,
+                scope=record.scope,
+                issued_monotonic=record.issued_monotonic,
+                consumed=True,
+            )
+        return "VERIFIED"
+
+
+_receipt_registry = _ReceiptRegistry()
+
+
+@dataclass
+class _RegistrationState:
+    claims: dict[str, object]
+    task_state_path: Path
+    provider_config_path: Path
+    task_record_hash: str
+    provider_config_hash: str
+
+    def is_current(self) -> bool:
+        try:
+            value = json.loads(self.task_state_path.read_text(encoding="utf-8"))
+            task_id = str(self.claims["identity"]["task_id"])  # type: ignore[index]
+            task = value["tasks"][task_id]
+            task_record = {
+                "task_id": task_id,
+                "status": task["status"],
+                "last_attempt": task["last_attempt"],
+            }
+            return (
+                task["status"] == "running"
+                and task["last_attempt"] == self.claims["identity"]["task_attempt_id"]  # type: ignore[index]
+                and _content_hash(task_record) == self.task_record_hash
+                and _file_hash(self.provider_config_path) == self.provider_config_hash
+            )
+        except (KeyError, OSError, TypeError, ValueError):
+            return False
+
+
+class _DispatchAuthorityServer:
+    def __init__(self, state: _RegistrationState) -> None:
+        self.capability = secrets.token_hex(32)
+        self.endpoint = f"@zenith-runtime-identity-{secrets.token_hex(24)}"
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.settimeout(0.25)
+        try:
+            listener.bind("\0" + self.endpoint[1:])
+            listener.listen(4)
+        except OSError:
+            listener.close()
+            raise
+        self._state = state
+        self._listener = listener
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._serve,
+            name="zenith-runtime-identity-dispatch",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def close(self) -> None:
+        self._stop.set()
+        self._listener.close()
+        self._thread.join(timeout=2)
+
+    def _serve(self) -> None:
+        request_count = 0
+        while not self._stop.is_set() and request_count < _MAX_REQUESTS_PER_DISPATCH:
+            try:
+                connection, _ = self._listener.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                return
+            request_count += 1
+            self._handle(connection)
+
+    def _handle(self, connection: socket.socket) -> None:
+        with connection:
+            connection.settimeout(_CONNECTION_TIMEOUT_SECONDS)
+            try:
+                payload = bytearray()
+                while len(payload) <= _MAX_MESSAGE_BYTES:
+                    chunk = connection.recv(4096)
+                    if not chunk:
+                        break
+                    payload.extend(chunk)
+                    if b"\n" in chunk:
+                        break
+                if len(payload) > _MAX_MESSAGE_BYTES or b"\n" not in payload:
+                    response = {"schema_version": 1, "state": "REJECTED"}
+                else:
+                    response = self._dispatch(json.loads(bytes(payload).split(b"\n", 1)[0]))
+            except (json.JSONDecodeError, OSError, TypeError, ValueError):
+                response = {"schema_version": 1, "state": "REJECTED"}
+            try:
+                connection.sendall(_canonical_json(response) + b"\n")
+            except OSError:
+                pass
+
+    def _dispatch(self, request: Any) -> dict[str, object]:
+        if not isinstance(request, dict) or request.get("schema_version") != 1:
+            return {"schema_version": 1, "state": "REJECTED"}
+        capability = request.get("capability")
+        nonce = request.get("nonce")
+        action = request.get("action")
+        if (
+            not secrets.compare_digest(
+                capability if isinstance(capability, str) else "",
+                self.capability,
+            )
+            or not isinstance(nonce, str)
+            or len(nonce) != 64
+            or action
+            not in {
+                "attest",
+                "consume",
+                "authorize_verdict",
+                "consume_verification",
+            }
+        ):
+            return {"schema_version": 1, "state": "REJECTED"}
+        if not self._state.is_current():
+            return {"schema_version": 1, "state": "REJECTED"}
+        if action == "attest":
+            identity = self._state.claims["identity"]
+            if not isinstance(identity, dict):
+                return {"schema_version": 1, "state": "REJECTED"}
+            channel_receipt_hash = _receipt_registry.issue_identity(
+                identity=identity,
+                runtime_receipt_hash=str(self._state.claims["runtime_receipt_hash"]),
+                nonce=nonce,
+                capability=self.capability,
+            )
+            return {
+                "schema_version": 1,
+                "state": "ATTESTED",
+                "authority_id": AUTHORITY_ID,
+                "controller_pid": os.getpid(),
+                "nonce": nonce,
+                "claims": self._state.claims,
+                "channel_receipt_hash": channel_receipt_hash,
+            }
+        if action in {"consume", "authorize_verdict"}:
+            identities = request.get("identities")
+            if (
+                not isinstance(identities, list)
+                or len(identities) > 8
+                or any(not isinstance(item, dict) for item in identities)
+            ):
+                return {"schema_version": 1, "state": "REJECTED"}
+            verdict_binding: tuple[str, ...] | None = None
+            authorizer_identity: dict[str, object] | None = None
+            if action == "authorize_verdict":
+                worker_manifest_hash = request.get("worker_manifest_hash")
+                verdict_set_hash = request.get("verdict_set_hash")
+                bundle_digest = request.get("bundle_digest")
+                if any(
+                    not isinstance(item, str) or len(item) != 64
+                    for item in (
+                        worker_manifest_hash,
+                        verdict_set_hash,
+                        bundle_digest,
+                    )
+                ):
+                    return {"schema_version": 1, "state": "REJECTED"}
+                current_identity = self._state.claims.get("identity")
+                if not isinstance(current_identity, dict):
+                    return {"schema_version": 1, "state": "REJECTED"}
+                authorizer_identity = current_identity
+                verdict_binding = (
+                    str(worker_manifest_hash),
+                    str(verdict_set_hash),
+                    str(bundle_digest),
+                )
+            state, receipt_hash = _receipt_registry.consume_identities(
+                identities,
+                nonce=nonce,
+                authorizer_identity=authorizer_identity,
+                verdict_binding=verdict_binding,
+            )
+            return {
+                "schema_version": 1,
+                "state": state,
+                "authority_id": AUTHORITY_ID,
+                "controller_pid": os.getpid(),
+                "nonce": nonce,
+                "verification_receipt_hash": receipt_hash,
+            }
+        receipt_hash = request.get("verification_receipt_hash")
+        binding_hashes = request.get("binding_hashes")
+        if (
+            not isinstance(receipt_hash, str)
+            or len(receipt_hash) != 64
+            or not isinstance(binding_hashes, list)
+            or len(binding_hashes) != 5
+            or any(not isinstance(item, str) or len(item) != 64 for item in binding_hashes)
+        ):
+            return {"schema_version": 1, "state": "REJECTED"}
+        current_identity = self._state.claims.get("identity")
+        if (
+            not isinstance(current_identity, dict)
+            or current_identity.get("task_type") != "validate"
+            or current_identity.get("execution_role") != "validator"
+        ):
+            return {"schema_version": 1, "state": "REJECTED"}
+        state = _receipt_registry.consume_verification(
+            receipt_hash,
+            tuple(binding_hashes),
+            current_identity,
+        )
+        return {
+            "schema_version": 1,
+            "state": state,
+            "authority_id": AUTHORITY_ID,
+            "controller_pid": os.getpid(),
+            "nonce": nonce,
+        }
+
+
+@dataclass
+class RuntimeIdentityRegistration:
+    endpoint: str | None
+    capability: str | None
+    reason_code: str = "PASS"
+    _server: _DispatchAuthorityServer | None = None
+
+    def environment(self) -> dict[str, str]:
+        if self.endpoint is None or self.capability is None:
+            return {}
+        return {
+            AUTHORITY_ENV_ENDPOINT: self.endpoint,
+            AUTHORITY_ENV_CAPABILITY: self.capability,
+        }
+
+    def close(self) -> None:
+        server = self._server
+        self._server = None
+        self.endpoint = None
+        self.capability = None
+        if server is not None:
+            server.close()
+
+
+def _register_node_runtime_identity(
+    *,
+    store: ProjectStore,
+    project_id: str,
+    mission_id: str,
+    task_id: str,
+    spawn_ts: str,
+    executor: str,
+    provider: str,
+    task_type: str,
+    execution_role: str,
+    workspace_dir: Path,
+) -> RuntimeIdentityRegistration:
+    config_relative_paths = {
+        "codex": Path(".codex/config.toml"),
+        "claude": Path(".claude/settings.json"),
+    }
+    try:
+        config_relative = config_relative_paths[provider]
+        workspace = workspace_dir.resolve(strict=True)
+        provider_config_path = (workspace / config_relative).resolve(strict=True)
+        task_state_path = (
+            store.mission_runtime_dir(project_id, mission_id) / "task-state.json"
+        ).resolve(strict=True)
+        task_state = store.load_task_state(project_id, mission_id)
+        task = task_state.tasks[task_id]
+        if task.status != "running" or task.last_attempt != spawn_ts:
+            return RuntimeIdentityRegistration(None, None, "TASK_ATTEMPT_NOT_RUNNING")
+        provider_config_hash = _file_hash(provider_config_path)
+        task_record = {
+            "task_id": task_id,
+            "status": task.status,
+            "last_attempt": task.last_attempt,
+        }
+        task_record_hash = _content_hash(task_record)
+        if (task_type, execution_role) not in {
+            ("work", "worker"),
+            ("validate", "validator"),
+        }:
+            return RuntimeIdentityRegistration(
+                None,
+                None,
+                "REGISTRATION_ROLE_INVALID",
+            )
+        identity = {
+            "schema_version": 1,
+            "orchestrator": "zenith",
+            "project_id": project_id,
+            "mission_id": mission_id,
+            "task_id": task_id,
+            "task_attempt_id": spawn_ts,
+            "executor": executor,
+            "provider": provider,
+            "task_type": task_type,
+            "execution_role": execution_role,
+            "provider_config_hash": provider_config_hash,
+            "attestation_state": "ATTESTED",
+        }
+        claims_base: dict[str, object] = {
+            "schema_version": 1,
+            "authority_id": AUTHORITY_ID,
+            "controller_runtime_root": str(REGISTERED_RUNTIME_ROOT),
+            "store_root": str(store.config.harness_home.resolve()),
+            "projects_root": str(store.config.projects_dir.resolve()),
+            "workspace_root": str(workspace),
+            "task_state_path": str(task_state_path),
+            "provider_config_path": str(provider_config_path),
+            "task_record_hash": task_record_hash,
+            "provider_config_hash": provider_config_hash,
+            "identity": identity,
+        }
+        claims = {
+            **claims_base,
+            "runtime_receipt_hash": _content_hash(claims_base),
+        }
+        state = _RegistrationState(
+            claims=claims,
+            task_state_path=task_state_path,
+            provider_config_path=provider_config_path,
+            task_record_hash=task_record_hash,
+            provider_config_hash=provider_config_hash,
+        )
+        server = _DispatchAuthorityServer(state)
+        return RuntimeIdentityRegistration(
+            server.endpoint,
+            server.capability,
+            _server=server,
+        )
+    except KeyError:
+        return RuntimeIdentityRegistration(None, None, "REGISTRATION_STATE_INVALID")
+    except FileNotFoundError:
+        return RuntimeIdentityRegistration(None, None, "REGISTRATION_INPUT_UNAVAILABLE")
+    except OSError as exc:
+        return RuntimeIdentityRegistration(
+            None,
+            None,
+            f"REGISTRATION_OS_ERROR_{exc.errno or 0}",
+        )
+    except (TypeError, ValueError):
+        return RuntimeIdentityRegistration(None, None, "REGISTRATION_INPUT_INVALID")
+
+
+def peer_credentials(connection: socket.socket) -> tuple[int, int, int]:
+    return struct.unpack(
+        "3i",
+        connection.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12),
+    )

--- a/zenith/src/zenith_harness/server.py
+++ b/zenith/src/zenith_harness/server.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import fcntl
 import logging
 import os
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable
 
 from fastmcp import Context, FastMCP
 from pydantic import Field
@@ -99,6 +100,49 @@ def create_terminal_reviewer_server() -> FastMCP:
 # ---------------------------------------------------------------------------
 
 
+def _run_project_locked(
+    controller: ProjectController,
+    project_id: str,
+    fn: Callable[..., Any],
+    *args: Any,
+) -> Any:
+    """Run a mutating controller call while holding an OS advisory lock whose
+    lifetime is tied to THIS WORKER THREAD, not to the async MCP request.
+
+    The tools hop into a thread via ``asyncio.to_thread``; a running thread's
+    future cannot be cancelled, so if the MCP request is aborted mid-wave (user
+    interrupt or client idle-abort) the thread keeps running to completion. The
+    in-process ``asyncio.Lock`` releases on that cancellation, which previously
+    let a retried call run concurrently and race on disk state
+    (task-state.json / attempts/*.json), stubbing still-in-flight validators and
+    failing gates on empty verdicts.
+
+    An advisory ``flock`` taken here — inside the thread, released only when the
+    file handle closes as this function returns — spans the true wave lifetime.
+    A concurrent mutating call gets ``wave_in_progress`` instead of racing.
+    """
+    runtime = controller.config.zenith_runtime_dir(project_id)
+    try:
+        runtime.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Project may not exist yet or path is unwritable; let the real call
+        # raise its own not_found/validation ToolError rather than masking it.
+        return fn(*args)
+    lock_path = runtime / ".wave.lock"
+    with open(lock_path, "w") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise ToolError(
+                "wave_in_progress",
+                "another mutating call is already running for this project; poll "
+                ".zenith-runtime/missions/<mid>/task-state.json and retry when the "
+                "wave is terminal (do not interrupt or re-issue a running "
+                "advance_project)",
+            ) from exc
+        return fn(*args)
+
+
 def _register_orchestrator_tools(mcp: FastMCP, controller: ProjectController) -> None:
     # Per-project lock around mutating controller calls. The thread hop in each
     # tool prevents event-loop blocking, but two same-project tool calls could
@@ -166,7 +210,14 @@ def _register_orchestrator_tools(mcp: FastMCP, controller: ProjectController) ->
         async with await _project_lock(project_id):
             try:
                 return _to_payload(
-                    await asyncio.to_thread(controller.submit_plan, project_id, task_list)
+                    await asyncio.to_thread(
+                        _run_project_locked,
+                        controller,
+                        project_id,
+                        controller.submit_plan,
+                        project_id,
+                        task_list,
+                    )
                 )
             except ToolError as exc:
                 return _to_payload(exc)
@@ -193,7 +244,14 @@ def _register_orchestrator_tools(mcp: FastMCP, controller: ProjectController) ->
         async with await _project_lock(project_id):
             try:
                 return _to_payload(
-                    await asyncio.to_thread(controller.advance_project, project_id, max_steps)
+                    await asyncio.to_thread(
+                        _run_project_locked,
+                        controller,
+                        project_id,
+                        controller.advance_project,
+                        project_id,
+                        max_steps,
+                    )
                 )
             except ToolError as exc:
                 return _to_payload(exc)
@@ -215,7 +273,13 @@ def _register_orchestrator_tools(mcp: FastMCP, controller: ProjectController) ->
         async with await _project_lock(project_id):
             try:
                 return _to_payload(
-                    await asyncio.to_thread(controller.end_mission, project_id)
+                    await asyncio.to_thread(
+                        _run_project_locked,
+                        controller,
+                        project_id,
+                        controller.end_mission,
+                        project_id,
+                    )
                 )
             except ToolError as exc:
                 return _to_payload(exc)
@@ -240,7 +304,14 @@ def _register_orchestrator_tools(mcp: FastMCP, controller: ProjectController) ->
         async with await _project_lock(project_id):
             try:
                 return _to_payload(
-                    await asyncio.to_thread(controller.decide_attention, project_id, decisions)
+                    await asyncio.to_thread(
+                        _run_project_locked,
+                        controller,
+                        project_id,
+                        controller.decide_attention,
+                        project_id,
+                        decisions,
+                    )
                 )
             except ToolError as exc:
                 return _to_payload(exc)
@@ -276,7 +347,14 @@ def _register_orchestrator_tools(mcp: FastMCP, controller: ProjectController) ->
         async with await _project_lock(project_id):
             try:
                 return _to_payload(
-                    await asyncio.to_thread(controller.abort_project, project_id, reason)
+                    await asyncio.to_thread(
+                        _run_project_locked,
+                        controller,
+                        project_id,
+                        controller.abort_project,
+                        project_id,
+                        reason,
+                    )
                 )
             except ToolError as exc:
                 return _to_payload(exc)

--- a/zenith/src/zenith_harness/server.py
+++ b/zenith/src/zenith_harness/server.py
@@ -10,6 +10,7 @@ import asyncio
 import fcntl
 import logging
 import os
+import stat
 from typing import Annotated, Any, Callable
 
 from fastmcp import Context, FastMCP
@@ -121,7 +122,7 @@ def _run_project_locked(
     file handle closes as this function returns — spans the true wave lifetime.
     A concurrent mutating call gets ``wave_in_progress`` instead of racing.
     """
-    runtime = controller.config.zenith_runtime_dir(project_id)
+    runtime = controller.store.zenith_runtime_dir(project_id)
     try:
         runtime.mkdir(parents=True, exist_ok=True)
     except OSError:
@@ -129,7 +130,24 @@ def _run_project_locked(
         # raise its own not_found/validation ToolError rather than masking it.
         return fn(*args)
     lock_path = runtime / ".wave.lock"
-    with open(lock_path, "w") as handle:
+    fd: int | None = None
+    try:
+        fd = os.open(
+            lock_path,
+            os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW,
+            0o600,
+        )
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise OSError("wave lock is not a regular file")
+    except OSError as exc:
+        if fd is not None:
+            os.close(fd)
+        raise ToolError(
+            "unsafe_wave_lock",
+            "the project wave lock is not a safe regular file",
+        ) from exc
+    assert fd is not None
+    with os.fdopen(fd, "r+") as handle:
         try:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc:

--- a/zenith/src/zenith_harness/storage.py
+++ b/zenith/src/zenith_harness/storage.py
@@ -137,13 +137,31 @@ class ProjectStore:
     # ------------------------------------------------------------------
 
     def bucket_root(self, project_id: str) -> Path:
-        return self.config.bucket_root(project_id)
+        return self._project_path(project_id)
 
     def zenith_dir(self, project_id: str) -> Path:
-        return self.config.zenith_dir(project_id)
+        return self._project_path(project_id, ".zenith")
 
     def zenith_runtime_dir(self, project_id: str) -> Path:
-        return self.config.zenith_runtime_dir(project_id)
+        return self._project_path(project_id, ".zenith-runtime")
+
+    def _project_path(self, project_id: str, *parts: str) -> Path:
+        if not project_id or Path(project_id).name != project_id:
+            raise ValueError(f"invalid project_id: {project_id!r}")
+        root = self.config.projects_dir.expanduser().resolve()
+        candidate = root / project_id
+        for part in parts:
+            candidate /= part
+        current = root
+        for part in candidate.relative_to(root).parts:
+            current /= part
+            if current.is_symlink():
+                raise ValueError(f"symlinked project path is not allowed: {current}")
+        try:
+            candidate.resolve(strict=False).relative_to(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ValueError(f"project path escapes projects_dir: {candidate}") from exc
+        return candidate
 
     def workspace_dir(self, project_id: str) -> Path:
         return Path(self.load_project(project_id).workspace_dir)
@@ -184,7 +202,7 @@ class ProjectStore:
         # 1) Durable layout (.zenith/)
         zenith.mkdir(parents=True, exist_ok=True)
         (zenith / "decisions").mkdir(parents=True, exist_ok=True)
-        (zenith / "skills").mkdir(parents=True, exist_ok=True)
+        skills = self._ensure_real_skills_dir(zenith / "skills")
         (zenith / "missions").mkdir(parents=True, exist_ok=True)
 
         # 2) Cursor layout (.zenith-runtime/)
@@ -217,8 +235,8 @@ class ProjectStore:
         # 6) Import existing repo-native host skills, then seed bundled skills
         #    into the bucket so host-agent native
         #    discovery via the workspace shim has content from day one.
-        self._import_workspace_skills(ws, zenith / "skills")
-        self._seed_bundled_skills(zenith / "skills")
+        self._import_workspace_skills(ws, skills)
+        self._seed_bundled_skills(skills)
 
         # 7) Workspace symlink shims (host-agent native discovery surface).
         self._ensure_symlink_shims(ws, zenith)
@@ -254,7 +272,7 @@ class ProjectStore:
         record = self.load_project(project_id)
         ws = Path(record.workspace_dir).expanduser().resolve()
         zenith = self.zenith_dir(project_id)
-        target_skills = zenith / "skills"
+        target_skills = self._ensure_real_skills_dir(zenith / "skills")
         self._import_workspace_skills(ws, target_skills)
         self._seed_bundled_skills(target_skills)
         self._ensure_symlink_shims(ws, zenith)
@@ -678,6 +696,8 @@ class ProjectStore:
         target_skills.mkdir(parents=True, exist_ok=True)
         for host in (".agents", ".claude", ".codex"):
             host_dir = workspace / host
+            if host_dir.is_symlink():
+                continue
             host_dir.mkdir(parents=True, exist_ok=True)
             self._ensure_skills_surface(host_dir / "skills", target_skills)
         self._ensure_agents_surface(workspace / "AGENTS.md", target_agents_md)
@@ -756,17 +776,30 @@ class ProjectStore:
     def _import_workspace_skills(self, workspace: Path, target: Path) -> None:
         target.mkdir(parents=True, exist_ok=True)
         for host in (".agents", ".claude", ".codex"):
-            source = workspace / host / "skills"
+            host_dir = workspace / host
+            if host_dir.is_symlink():
+                continue
+            source = host_dir / "skills"
             if source.is_dir() and not source.is_symlink():
                 self._copy_missing_tree(source, target)
+
+    @staticmethod
+    def _ensure_real_skills_dir(path: Path) -> Path:
+        if path.is_symlink():
+            path.unlink()
+        path.mkdir(parents=True, exist_ok=True)
+        return path
 
     def _seed_bundled_skills(self, target: Path) -> None:
         """Copy bundled `SKILL.md` files into the bucket if not already
         present. Idempotent and non-overwriting per skill."""
+        if target.is_symlink():
+            return
         bundled_skills = self.config.bundled_dir / "skills"
         if not bundled_skills.exists():
             return
         target.mkdir(parents=True, exist_ok=True)
+        target_root = target.resolve()
         for skill_dir in sorted(bundled_skills.iterdir()):
             if not skill_dir.is_dir():
                 continue
@@ -775,27 +808,114 @@ class ProjectStore:
                 continue
             dest_dir = target / skill_dir.name
             dest = dest_dir / "SKILL.md"
-            if dest.exists():
+            if dest_dir.is_symlink():
+                dest_dir.unlink()
+            if os.path.lexists(dest):
+                if dest.is_symlink():
+                    dest.unlink()
+                else:
+                    continue
+            if os.path.lexists(dest_dir) and not dest_dir.is_dir():
                 continue
             dest_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                dest_dir.resolve(strict=True).relative_to(target_root)
+            except (OSError, RuntimeError, ValueError):
+                continue
             shutil.copy2(src, dest)
 
     @staticmethod
     def _copy_missing_tree(source: Path, target: Path) -> None:
-        if not source.is_dir():
+        if not source.is_dir() or target.is_symlink():
             return
+        allowed_root = source.parents[1].resolve()
+        try:
+            source.resolve(strict=True).relative_to(allowed_root)
+        except (FileNotFoundError, OSError, RuntimeError, ValueError):
+            return
+        target_root = target.resolve()
         for src in sorted(source.rglob("*")):
+            try:
+                resolved_src = src.resolve(strict=True)
+                resolved_src.relative_to(allowed_root)
+            except (FileNotFoundError, OSError, RuntimeError, ValueError):
+                continue
             rel = src.relative_to(source)
             dest = target / rel
             if os.path.lexists(dest):
-                continue
+                if dest.is_symlink():
+                    dest.unlink()
+                else:
+                    continue
             dest.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                dest.parent.resolve().relative_to(target_root)
+            except (OSError, RuntimeError, ValueError):
+                continue
             if src.is_symlink():
-                dest.symlink_to(os.readlink(src))
+                try:
+                    resolved_src.relative_to(allowed_root)
+                except ValueError:
+                    continue
+                if resolved_src.is_dir():
+                    ProjectStore._copy_resolved_tree(
+                        resolved_src, dest, allowed_root, target_root, set()
+                    )
+                elif resolved_src.is_file():
+                    shutil.copy2(resolved_src, dest)
             elif src.is_dir():
                 dest.mkdir(parents=True, exist_ok=True)
             elif src.is_file():
                 shutil.copy2(src, dest)
+
+    @staticmethod
+    def _copy_resolved_tree(
+        source: Path,
+        target: Path,
+        allowed_root: Path,
+        target_root: Path,
+        visited: set[Path],
+    ) -> None:
+        try:
+            resolved_source = source.resolve(strict=True)
+            resolved_source.relative_to(allowed_root)
+        except (FileNotFoundError, OSError, RuntimeError, ValueError):
+            return
+        if resolved_source in visited:
+            return
+        visited.add(resolved_source)
+        if os.path.lexists(target) and target.is_symlink():
+            target.unlink()
+        try:
+            target.parent.resolve().relative_to(target_root)
+        except (OSError, RuntimeError, ValueError):
+            return
+        target.mkdir(parents=True, exist_ok=True)
+        for child in sorted(resolved_source.iterdir()):
+            destination = target / child.name
+            try:
+                resolved_child = child.resolve(strict=True)
+                resolved_child.relative_to(allowed_root)
+            except (FileNotFoundError, OSError, RuntimeError, ValueError):
+                continue
+            if resolved_child.is_dir():
+                if os.path.lexists(destination) and destination.is_symlink():
+                    destination.unlink()
+                ProjectStore._copy_resolved_tree(
+                    resolved_child,
+                    destination,
+                    allowed_root,
+                    target_root,
+                    visited,
+                )
+            elif resolved_child.is_file():
+                if os.path.lexists(destination) and destination.is_symlink():
+                    destination.unlink()
+                try:
+                    destination.parent.resolve().relative_to(target_root)
+                except (OSError, RuntimeError, ValueError):
+                    continue
+                shutil.copy2(resolved_child, destination)
 
 
 __all__ = [

--- a/zenith/tests/fake_runtime_identity_controller.py
+++ b/zenith/tests/fake_runtime_identity_controller.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from self_improvement_release import RuntimeIdentityAuthority
+from zenith_harness.config import HarnessConfig
+from zenith_harness.runtime_identity import _register_node_runtime_identity
+from zenith_harness.storage import ProjectStore
+
+
+def main() -> int:
+    harness_home = Path(sys.argv[1]).resolve()
+    workspace = Path(sys.argv[2]).resolve()
+    project_id = sys.argv[3]
+    mission_id = sys.argv[4]
+    task_id = sys.argv[5]
+    attempt = sys.argv[6]
+    identity_path = Path(sys.argv[7])
+    config = HarnessConfig(
+        bundled_dir=Path(__file__).resolve().parents[1] / "src" / "zenith_harness" / "bundled",
+        harness_home=harness_home,
+        projects_dir=harness_home / "projects",
+        orchestrator_provider_name="claude",
+        worker_provider_name="claude",
+        worker_acp_command=None,
+        validator_provider_name=None,
+        validator_acp_command=None,
+        terminal_reviewer_provider_name=None,
+        terminal_reviewer_acp_command=None,
+    )
+    store = ProjectStore(config)
+    registration = _register_node_runtime_identity(
+        store=store,
+        project_id=project_id,
+        mission_id=mission_id,
+        task_id=task_id,
+        spawn_ts=attempt,
+        executor="claude-worker",
+        provider="claude",
+        task_type="work",
+        execution_role="worker",
+        workspace_dir=workspace,
+    )
+    if registration.endpoint is None or registration.capability is None:
+        print("REJECTED")
+        return 0
+    with patch.dict(os.environ, registration.environment(), clear=False):
+        identity = RuntimeIdentityAuthority.from_current_zenith_runtime().issue()
+    identity_path.write_text(
+        json.dumps(identity.to_mapping()),
+        encoding="utf-8",
+    )
+    print("MINTED")
+    registration.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zenith/tests/mock_acp_agent.py
+++ b/zenith/tests/mock_acp_agent.py
@@ -17,14 +17,18 @@ Environment variables read from os.environ:
   ZENITH_NODE_TYPE     — work | validate (controls the handoff shape)
   ZENITH_VALIDATION_PASSED — '1' to mark items passed=true (validate only)
   MOCK_ACP_CRASH       — '1' to exit immediately without writing
+  MOCK_ACP_SKIP_FIRST_HANDOFF — '1' to omit the first prompt handoff
+  MOCK_ACP_HANG_ON_SECOND_PROMPT — '1' to omit the second prompt response
   MOCK_ACP_REQUEST_ATTENTION — '1' to set request_attention=true
   MOCK_ACP_DONE        — '0' to set done=false (default '1')
+  MOCK_ACP_STDERR_BYTES — number of stderr bytes to emit before serving requests
 """
 
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -61,6 +65,30 @@ def _write_handoff() -> None:
     tmp.replace(target)
 
 
+def _run_probe(command_name: str, output_name: str) -> None:
+    raw_command = os.environ.get(command_name)
+    output_path = os.environ.get(output_name)
+    if not raw_command or not output_path:
+        return
+    command = json.loads(raw_command)
+    result = subprocess.run(
+        command,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    Path(output_path).write_text(
+        json.dumps(
+            {
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def _response(req_id, result):
     return {"jsonrpc": "2.0", "id": req_id, "result": result}
 
@@ -72,6 +100,13 @@ def _error(req_id, code, message):
 def main() -> None:
     if os.environ.get("MOCK_ACP_CRASH") == "1":
         sys.exit(1)
+    remaining_stderr = int(os.environ.get("MOCK_ACP_STDERR_BYTES", "0"))
+    stderr_chunk = b"e" * (64 * 1024)
+    while remaining_stderr > 0:
+        chunk = stderr_chunk[:remaining_stderr]
+        os.write(2, chunk)
+        remaining_stderr -= len(chunk)
+    prompt_count = 0
     for line in sys.stdin:
         line = line.strip()
         if not line:
@@ -83,24 +118,44 @@ def main() -> None:
         method = msg.get("method")
         req_id = msg.get("id")
         if method == "initialize":
-            resp = _response(req_id, {
-                "protocolVersion": 1,
-                "agentCapabilities": {
-                    "loadSession": False,
-                    "promptCapabilities": {
-                        "audio": False,
-                        "embeddedContent": False,
-                        "image": False,
+            resp = _response(
+                req_id,
+                {
+                    "protocolVersion": 1,
+                    "agentCapabilities": {
+                        "loadSession": False,
+                        "promptCapabilities": {
+                            "audio": False,
+                            "embeddedContent": False,
+                            "image": False,
+                        },
                     },
+                    "authMethods": [],
                 },
-                "authMethods": [],
-            })
+            )
         elif method == "session/new":
             resp = _response(req_id, {"sessionId": "mock-session-1"})
         elif method == "session/set_mode":
             resp = _response(req_id, {})
         elif method == "session/prompt":
-            _write_handoff()
+            prompt_count += 1
+            if prompt_count == 1:
+                _run_probe(
+                    "MOCK_ACP_RUNTIME_IDENTITY_COMMAND",
+                    "MOCK_ACP_RUNTIME_IDENTITY_OUTPUT",
+                )
+                _run_probe(
+                    "MOCK_ACP_FAKE_CONTROLLER_COMMAND",
+                    "MOCK_ACP_FAKE_CONTROLLER_OUTPUT",
+                )
+                _run_probe(
+                    "MOCK_ACP_FAKE_IDENTITY_VERIFY_COMMAND",
+                    "MOCK_ACP_FAKE_IDENTITY_VERIFY_OUTPUT",
+                )
+            if os.environ.get("MOCK_ACP_HANG_ON_SECOND_PROMPT") == "1" and prompt_count == 2:
+                continue
+            if not (os.environ.get("MOCK_ACP_SKIP_FIRST_HANDOFF") == "1" and prompt_count == 1):
+                _write_handoff()
             resp = _response(req_id, {"stopReason": "end_turn"})
         else:
             resp = _error(req_id, -32601, "Method not found")

--- a/zenith/tests/test_acp_runner.py
+++ b/zenith/tests/test_acp_runner.py
@@ -5,18 +5,23 @@ We don't run a real `claude-agent-acp` here; we use the bundled
 mechanic. The worker MCP server subprocess is bypassed: the mock agent
 writes directly to ZENITH_HANDOFF_PATH itself.
 """
+
 from __future__ import annotations
 
 import asyncio
 import json
 import os
 import shutil
+import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
+from zenith_harness import acp_runner
 from zenith_harness.acp_runner import (
+    ACPClient,
     ACPNodeRunner,
     _acp_subprocess_env,
     _augment_acp_command,
@@ -24,7 +29,8 @@ from zenith_harness.acp_runner import (
 from zenith_harness.providers import PROVIDERS
 from zenith_harness.assets import AssetLoader
 from zenith_harness.config import HarnessConfig
-from zenith_harness.models import Task, WorkHandoff
+from zenith_harness.models import Task, ValidateHandoff, WorkHandoff
+from zenith_harness.runtime_identity import RuntimeIdentityRegistration
 from zenith_harness.storage import ProjectStore
 
 
@@ -45,8 +51,8 @@ def config(harness_home: Path, mock_acp_command: str) -> HarnessConfig:
         orchestrator_provider_name="claude",
         worker_provider_name="claude",
         worker_acp_command=mock_acp_command,
-        validator_provider_name=None,
-        validator_acp_command=None,
+        validator_provider_name="claude",
+        validator_acp_command=mock_acp_command,
         terminal_reviewer_provider_name=None,
         terminal_reviewer_acp_command=None,
     )
@@ -61,6 +67,21 @@ def project_setup(config: HarnessConfig, workspace: Path):
     return store
 
 
+def _prepare_runtime_identity(
+    store: ProjectStore,
+    workspace: Path,
+    task: Task,
+    spawn_ts: str,
+) -> None:
+    provider_config = workspace / ".claude/settings.json"
+    provider_config.parent.mkdir(parents=True, exist_ok=True)
+    provider_config.write_text("{}\n", encoding="utf-8")
+    task_state = store.load_task_state("p1", "mission-001")
+    task_state.set_status(task.id, "running")
+    task_state.set_last_attempt(task.id, spawn_ts)
+    store.save_task_state("p1", "mission-001", task_state)
+
+
 # ---------------------------------------------------------------------------
 # Mock-agent integration: the agent writes directly to ZENITH_HANDOFF_PATH
 # ---------------------------------------------------------------------------
@@ -70,9 +91,7 @@ def project_setup(config: HarnessConfig, workspace: Path):
     not shutil.which("python3") and not Path(sys.executable).exists(),
     reason="Python interpreter unavailable",
 )
-def test_run_node_with_mock_agent(
-    config: HarnessConfig, project_setup, workspace: Path
-):
+def test_run_node_with_mock_agent(config: HarnessConfig, project_setup, workspace: Path):
     """End-to-end via the mock agent (NO real worker MCP server subprocess —
     we point at a free port that nothing binds to and rely on the mock to
     write the handoff file itself).
@@ -82,6 +101,7 @@ def test_run_node_with_mock_agent(
     spawn_ts = "2026-05-17T00-00-00Z"
     handoff_path = store.attempt_path("p1", "mission-001", spawn_ts, "w1")
     handoff_path.parent.mkdir(parents=True, exist_ok=True)
+    _prepare_runtime_identity(store, workspace, task, spawn_ts)
 
     os.environ["ZENITH_HANDOFF_PATH"] = str(handoff_path)
     os.environ["ZENITH_NODE_ID"] = task.id
@@ -92,7 +112,8 @@ def test_run_node_with_mock_agent(
 
         async def _no_op_server(*args, **kwargs):
             return await asyncio.create_subprocess_exec(
-                "sleep", "30",
+                "sleep",
+                "30",
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             )
@@ -124,6 +145,162 @@ def test_run_node_with_mock_agent(
     assert data["node_id"] == "w1"
 
 
+def test_run_node_issues_identity_from_live_production_controller_and_blocks_fake(
+    config: HarnessConfig,
+    project_setup,
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = project_setup
+    task = Task(id="w-identity", type="work", body="identity", targets=[], skill="s")
+    spawn_ts = "2026-07-23T00-00-00Z"
+    task_state = store.load_task_state("p1", "mission-001")
+    task_state.set_status(task.id, "running")
+    task_state.set_last_attempt(task.id, spawn_ts)
+    store.save_task_state("p1", "mission-001", task_state)
+    handoff_path = store.attempt_path("p1", "mission-001", spawn_ts, task.id)
+    identity_output = tmp_path / "runtime-identity.json"
+    fake_controller_output = tmp_path / "fake-controller.json"
+    fake_identity = tmp_path / "fake-identity.json"
+    fake_verify_output = tmp_path / "fake-verify.json"
+    fake_controller = Path(__file__).resolve().parent / "fake_runtime_identity_controller.py"
+    product_root = Path("/home/lenovo/workspaces/cursor/projects/active/harness-belief-remediation")
+    harness_source = Path(__file__).resolve().parents[1] / "src"
+    python_path = os.pathsep.join(
+        [str(product_root), str(harness_source), os.environ.get("PYTHONPATH", "")]
+    )
+    monkeypatch.setenv("PYTHONPATH", python_path)
+    monkeypatch.setenv("ZENITH_HANDOFF_PATH", str(handoff_path))
+    monkeypatch.setenv("ZENITH_NODE_ID", task.id)
+    monkeypatch.setenv("ZENITH_NODE_TYPE", task.type)
+    monkeypatch.setenv(
+        "MOCK_ACP_RUNTIME_IDENTITY_COMMAND",
+        json.dumps(
+            [
+                sys.executable,
+                "-m",
+                "self_improvement_release",
+                "runtime-identity",
+            ]
+        ),
+    )
+    monkeypatch.setenv("MOCK_ACP_RUNTIME_IDENTITY_OUTPUT", str(identity_output))
+    monkeypatch.setenv(
+        "MOCK_ACP_FAKE_CONTROLLER_COMMAND",
+        json.dumps(
+            [
+                sys.executable,
+                str(fake_controller),
+                str(config.harness_home),
+                str(workspace),
+                "p1",
+                "mission-001",
+                task.id,
+                spawn_ts,
+                str(fake_identity),
+            ]
+        ),
+    )
+    monkeypatch.setenv("MOCK_ACP_FAKE_CONTROLLER_OUTPUT", str(fake_controller_output))
+    monkeypatch.setenv(
+        "MOCK_ACP_FAKE_IDENTITY_VERIFY_COMMAND",
+        json.dumps(
+            [
+                sys.executable,
+                "-m",
+                "self_improvement_release",
+                "runtime-identity",
+                "--input",
+                str(fake_identity),
+            ]
+        ),
+    )
+    monkeypatch.setenv(
+        "MOCK_ACP_FAKE_IDENTITY_VERIFY_OUTPUT",
+        str(fake_verify_output),
+    )
+    captured_identity_environment: dict[str, str] = {}
+    original_subprocess_env = acp_runner._acp_subprocess_env
+
+    def _capture_subprocess_env(provider, **kwargs):
+        environment = original_subprocess_env(provider, **kwargs)
+        for name in (
+            "SELF_IMPROVEMENT_ZENITH_AUTHORITY_ENDPOINT",
+            "SELF_IMPROVEMENT_ZENITH_AUTHORITY_CAPABILITY",
+        ):
+            if value := environment.get(name):
+                captured_identity_environment[name] = value
+        return environment
+
+    monkeypatch.setattr(acp_runner, "_acp_subprocess_env", _capture_subprocess_env)
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+
+    async def _no_op_server(*args, **kwargs):
+        return await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def _ready_immediately(*args, **kwargs):
+        return None
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready_immediately  # type: ignore[method-assign]
+    handoff = asyncio.run(
+        runner.run_node(
+            project_id="p1",
+            mission_id="mission-001",
+            task=task,
+            spawn_ts=spawn_ts,
+            store=store,
+        )
+    )
+
+    assert isinstance(handoff, WorkHandoff)
+    assert handoff.done is True
+    identity_probe = json.loads(identity_output.read_text(encoding="utf-8"))
+    assert identity_probe["returncode"] == 0, identity_probe
+    identity_result = json.loads(identity_probe["stdout"])
+    assert identity_result["disposition"] == "PROMOTE"
+    identity = identity_result["identity"]
+    assert identity["project_id"] == "p1"
+    assert identity["mission_id"] == "mission-001"
+    assert identity["task_id"] == task.id
+    assert identity["task_attempt_id"] == spawn_ts
+    assert identity["executor"] == "claude-worker"
+    assert identity["provider"] == "claude"
+    fake_probe = json.loads(fake_controller_output.read_text(encoding="utf-8"))
+    assert fake_probe["returncode"] == 0
+    assert fake_probe["stdout"].strip() == "MINTED"
+    fake_verify = json.loads(fake_verify_output.read_text(encoding="utf-8"))
+    assert fake_verify["returncode"] == 30
+    assert json.loads(fake_verify["stdout"])["reason_code"] == ("IDENTITY_ATTESTATION_INVALID")
+    closed_registration = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "self_improvement_release",
+            "runtime-identity",
+        ],
+        cwd=product_root,
+        env={
+            **os.environ,
+            **captured_identity_environment,
+            "PYTHONPATH": python_path,
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert closed_registration.returncode == 20
+    assert json.loads(closed_registration.stdout)["reason_code"] == (
+        "RUNTIME_AUTHORITY_UNAVAILABLE"
+    )
+
+
 def test_synthesize_missing_handoff_records_failure(
     config: HarnessConfig, project_setup, workspace: Path
 ):
@@ -145,6 +322,209 @@ def test_synthesize_missing_handoff_records_failure(
     assert handoff.done is False
     assert "stop_reason=cancelled" in handoff.report
     assert handoff_path.exists()
+
+
+def test_send_request_cancellation_during_write_cleans_pending():
+    client = ACPClient(object(), ".")  # type: ignore[arg-type]
+    write_started = asyncio.Event()
+
+    async def _blocked_write(message):
+        write_started.set()
+        await asyncio.Event().wait()
+
+    client._write = _blocked_write  # type: ignore[method-assign]
+
+    async def _scenario():
+        request = asyncio.create_task(client.send_request("method", {}))
+        await write_started.wait()
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+        assert client._pending == {}
+
+    asyncio.run(_scenario())
+
+
+@pytest.mark.skipif(
+    not shutil.which("python3") and not Path(sys.executable).exists(),
+    reason="Python interpreter unavailable",
+)
+def test_run_node_repairs_end_turn_without_handoff(
+    config: HarnessConfig,
+    project_setup,
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An ACP prose-only first turn gets one same-session end_node retry."""
+    store = project_setup
+    task = Task(
+        id="v1",
+        type="validate",
+        body="validate it",
+        targets=["VAL-001"],
+        skill="s",
+    )
+    spawn_ts = "2026-05-17T00-00-01Z"
+    handoff_path = store.attempt_path("p1", "mission-001", spawn_ts, "v1")
+    handoff_path.parent.mkdir(parents=True, exist_ok=True)
+    _prepare_runtime_identity(store, workspace, task, spawn_ts)
+
+    monkeypatch.setenv("ZENITH_HANDOFF_PATH", str(handoff_path))
+    monkeypatch.setenv("ZENITH_NODE_ID", task.id)
+    monkeypatch.setenv("ZENITH_NODE_TYPE", task.type)
+    monkeypatch.setenv("MOCK_ACP_SKIP_FIRST_HANDOFF", "1")
+    monkeypatch.setenv("MOCK_ACP_DONE", "1")
+    monkeypatch.setenv("ZENITH_VALIDATION_PASSED", "1")
+    monkeypatch.setenv("MOCK_ACP_REQUEST_ATTENTION", "0")
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+
+    async def _no_op_server(*args, **kwargs):
+        return await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def _ready_immediately(*args, **kwargs):
+        return None
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready_immediately  # type: ignore[method-assign]
+
+    handoff = asyncio.run(
+        runner.run_node(
+            project_id="p1",
+            mission_id="mission-001",
+            task=task,
+            spawn_ts=spawn_ts,
+            store=store,
+        )
+    )
+
+    assert isinstance(handoff, ValidateHandoff)
+    assert handoff.done is True
+    assert handoff.passed is True
+    assert handoff.items[0].item_id == "VAL-001"
+
+
+@pytest.mark.skipif(
+    not shutil.which("python3") and not Path(sys.executable).exists(),
+    reason="Python interpreter unavailable",
+)
+def test_run_node_does_not_retry_mutation_capable_worker(
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = project_setup
+    task = Task(id="w2", type="work", body="mutate", targets=[], skill="s")
+    spawn_ts = "2026-05-17T00-00-02Z"
+    handoff_path = store.attempt_path("p1", "mission-001", spawn_ts, "w2")
+    _prepare_runtime_identity(
+        store,
+        store.workspace_dir("p1"),
+        task,
+        spawn_ts,
+    )
+    monkeypatch.setenv("ZENITH_HANDOFF_PATH", str(handoff_path))
+    monkeypatch.setenv("ZENITH_NODE_ID", task.id)
+    monkeypatch.setenv("ZENITH_NODE_TYPE", task.type)
+    monkeypatch.setenv("MOCK_ACP_SKIP_FIRST_HANDOFF", "1")
+    monkeypatch.setenv("MOCK_ACP_DONE", "1")
+    monkeypatch.setenv("MOCK_ACP_REQUEST_ATTENTION", "0")
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+
+    async def _no_op_server(*args, **kwargs):
+        return await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def _ready_immediately(*args, **kwargs):
+        return None
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready_immediately  # type: ignore[method-assign]
+    handoff = asyncio.run(
+        runner.run_node(
+            project_id="p1",
+            mission_id="mission-001",
+            task=task,
+            spawn_ts=spawn_ts,
+            store=store,
+        )
+    )
+
+    assert isinstance(handoff, WorkHandoff)
+    assert handoff.done is False
+    assert "without calling end_node" in handoff.report
+
+
+@pytest.mark.skipif(
+    not shutil.which("python3") and not Path(sys.executable).exists(),
+    reason="Python interpreter unavailable",
+)
+def test_run_node_times_out_nonresponsive_validator_repair(
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = project_setup
+    task = Task(
+        id="v2",
+        type="validate",
+        body="validate it",
+        targets=["VAL-001"],
+        skill="s",
+    )
+    spawn_ts = "2026-05-17T00-00-03Z"
+    handoff_path = store.attempt_path("p1", "mission-001", spawn_ts, "v2")
+    _prepare_runtime_identity(
+        store,
+        store.workspace_dir("p1"),
+        task,
+        spawn_ts,
+    )
+    monkeypatch.setenv("ZENITH_HANDOFF_PATH", str(handoff_path))
+    monkeypatch.setenv("ZENITH_NODE_ID", task.id)
+    monkeypatch.setenv("ZENITH_NODE_TYPE", task.type)
+    monkeypatch.setenv("MOCK_ACP_SKIP_FIRST_HANDOFF", "1")
+    monkeypatch.setenv("MOCK_ACP_HANG_ON_SECOND_PROMPT", "1")
+    monkeypatch.setenv("MOCK_ACP_DONE", "1")
+    monkeypatch.setenv("ZENITH_VALIDATION_PASSED", "1")
+    monkeypatch.setenv("MOCK_ACP_REQUEST_ATTENTION", "0")
+    monkeypatch.setattr(acp_runner, "HANDOFF_REPAIR_TIMEOUT_SECONDS", 0.1)
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+
+    async def _no_op_server(*args, **kwargs):
+        return await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def _ready_immediately(*args, **kwargs):
+        return None
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready_immediately  # type: ignore[method-assign]
+    handoff = asyncio.run(
+        runner.run_node(
+            project_id="p1",
+            mission_id="mission-001",
+            task=task,
+            spawn_ts=spawn_ts,
+            store=store,
+        )
+    )
+
+    assert isinstance(handoff, ValidateHandoff)
+    assert handoff.done is False
+    assert "protocol repair timed out" in handoff.report
 
 
 def test_augment_acp_command_codex_appends_bypass_flags():
@@ -175,6 +555,627 @@ def test_codex_acp_env_preserves_node_path_when_bwrap_is_present(
     assert str(bin_dir) in env["PATH"].split(os.pathsep)
     assert env["CODEX_SANDBOX"] == "danger-full-access"
     assert env["CODEX_DISABLE_SANDBOX"] == "1"
+
+
+def test_acp_environment_scrubs_ambient_authority_and_adds_only_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "SELF_IMPROVEMENT_ZENITH_AUTHORITY_ENDPOINT",
+        "SELF_IMPROVEMENT_ZENITH_AUTHORITY_CAPABILITY",
+        "SELF_IMPROVEMENT_ZENITH_AUTHORITY_TOKEN",
+        "SELF_IMPROVEMENT_ZENITH_ISSUER_STATE",
+    ):
+        monkeypatch.setenv(name, "ambient")
+
+    terminal_environment = _acp_subprocess_env(PROVIDERS["claude"])
+    assert not any(
+        name.startswith("SELF_IMPROVEMENT_ZENITH_AUTHORITY_") for name in terminal_environment
+    )
+    assert "SELF_IMPROVEMENT_ZENITH_ISSUER_STATE" not in terminal_environment
+
+    dispatch_environment = _acp_subprocess_env(
+        PROVIDERS["claude"],
+        runtime_identity_environment={
+            "SELF_IMPROVEMENT_ZENITH_AUTHORITY_ENDPOINT": "@endpoint",
+            "SELF_IMPROVEMENT_ZENITH_AUTHORITY_CAPABILITY": "capability",
+        },
+    )
+    assert dispatch_environment["SELF_IMPROVEMENT_ZENITH_AUTHORITY_ENDPOINT"] == "@endpoint"
+    assert dispatch_environment["SELF_IMPROVEMENT_ZENITH_AUTHORITY_CAPABILITY"] == "capability"
+    assert "SELF_IMPROVEMENT_ZENITH_AUTHORITY_TOKEN" not in dispatch_environment
+
+
+def test_failed_identity_registration_refuses_agent_spawn(
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = Task(id="w-refuse", type="work", body="b", targets=[], skill="s")
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+
+    async def _no_op_server(*args, **kwargs):
+        return await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def _ready_immediately(*args, **kwargs):
+        return None
+
+    async def _unexpected_spawn(*args, **kwargs):
+        raise AssertionError("ACP spawn must not occur")
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready_immediately  # type: ignore[method-assign]
+    runner._register_runtime_identity = lambda **kwargs: RuntimeIdentityRegistration(  # type: ignore[method-assign]
+        None,
+        None,
+        "REGISTRATION_INPUT_UNAVAILABLE",
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _unexpected_spawn)
+
+    handoff = asyncio.run(
+        runner.run_node(
+            "p1",
+            "mission-001",
+            task,
+            "attempt-refuse",
+            project_setup,
+        )
+    )
+    assert handoff.done is False
+    assert "REGISTRATION_INPUT_UNAVAILABLE" in handoff.report
+
+
+@pytest.mark.parametrize("cancel_point", ["readiness", "spawn", "client_start"])
+def test_run_node_cancellation_closes_acquired_resources(
+    cancel_point: str,
+    config: HarnessConfig,
+    project_setup,
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = Task(
+        id=f"w-cancel-{cancel_point}",
+        type="work",
+        body="b",
+        targets=[],
+        skill="s",
+    )
+    spawn_ts = f"attempt-{cancel_point}"
+    _prepare_runtime_identity(project_setup, workspace, task, spawn_ts)
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+    mcp_processes: list[asyncio.subprocess.Process] = []
+    registrations: list[RuntimeIdentityRegistration] = []
+    original_register = runner._register_runtime_identity
+
+    async def _no_op_server(*args, **kwargs):
+        process = await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        mcp_processes.append(process)
+        return process
+
+    async def _ready(*args, **kwargs):
+        if cancel_point == "readiness":
+            raise asyncio.CancelledError
+
+    def _register(**kwargs):
+        registration = original_register(**kwargs)
+        registrations.append(registration)
+        return registration
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    runner._register_runtime_identity = _register  # type: ignore[method-assign]
+    if cancel_point == "spawn":
+
+        async def _cancel_spawn(*args, **kwargs):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "create_subprocess_shell", _cancel_spawn)
+    elif cancel_point == "client_start":
+
+        async def _cancel_start(self):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(ACPClient, "start", _cancel_start)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            runner.run_node(
+                "p1",
+                "mission-001",
+                task,
+                spawn_ts,
+                project_setup,
+            )
+        )
+    assert mcp_processes and mcp_processes[0].returncode is not None
+    if registrations:
+        assert registrations[0].endpoint is None
+        assert registrations[0].capability is None
+
+
+@pytest.mark.parametrize("cancel_point", ["readiness", "spawn", "client_start"])
+def test_terminal_review_cancellation_closes_acquired_resources(
+    cancel_point: str,
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    terminal_config = replace(
+        config,
+        terminal_reviewer_provider_name="claude",
+        terminal_reviewer_acp_command=config.worker_acp_command,
+    )
+    runner = ACPNodeRunner(
+        config=terminal_config,
+        loader=AssetLoader(terminal_config),
+    )
+    mcp_processes: list[asyncio.subprocess.Process] = []
+    acp_processes: list[asyncio.subprocess.Process] = []
+    original_spawn = asyncio.create_subprocess_shell
+
+    async def _no_op_server(*args, **kwargs):
+        process = await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        mcp_processes.append(process)
+        return process
+
+    async def _ready(*args, **kwargs):
+        if cancel_point == "readiness":
+            raise asyncio.CancelledError
+
+    async def _spawn(*args, **kwargs):
+        if cancel_point == "spawn":
+            raise asyncio.CancelledError
+        process = await original_spawn(*args, **kwargs)
+        acp_processes.append(process)
+        return process
+
+    runner._start_terminal_reviewer_mcp = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _spawn)
+    if cancel_point == "client_start":
+
+        async def _cancel_start(self):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(ACPClient, "start", _cancel_start)
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(
+                runner.run_terminal_review(
+                    "p1",
+                    "mission-001",
+                    f"attempt-{cancel_point}",
+                    project_setup,
+                )
+            )
+        assert mcp_processes and mcp_processes[0].returncode is not None
+        if acp_processes:
+            assert acp_processes[0].returncode is not None
+    finally:
+        for process in [*acp_processes, *mcp_processes]:
+            if process.returncode is None:
+                process.kill()
+
+
+def test_chatty_mcp_subprocess_cannot_fill_parent_pipe(
+    config: HarnessConfig,
+    project_setup,
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chatty_python = tmp_path / "chatty-python"
+    chatty_python.write_text(
+        (
+            f"#!{sys.executable}\n"
+            "import os\n"
+            "os.write(1, b'x' * (1024 * 1024))\n"
+            "os.write(2, b'y' * (1024 * 1024))\n"
+        ),
+        encoding="utf-8",
+    )
+    chatty_python.chmod(0o755)
+    monkeypatch.setattr(acp_runner.sys, "executable", str(chatty_python))
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+    task = Task(id="w-chatty", type="work", body="b", targets=[], skill="s")
+
+    async def _exercise() -> tuple[int | None, object, object]:
+        process = await runner._start_worker_mcp_server(
+            task=task,
+            project_id="p1",
+            mission_id="mission-001",
+            handoff_path=str(tmp_path / "handoff.json"),
+            workspace_dir=str(workspace),
+            mcp_port=runner._find_free_port(),
+        )
+        await asyncio.wait_for(process.wait(), timeout=2)
+        return process.returncode, process.stdout, process.stderr
+
+    returncode, stdout, stderr = asyncio.run(_exercise())
+    assert returncode == 0
+    assert stdout is None
+    assert stderr is None
+
+
+def test_progress_callback_exception_is_isolated() -> None:
+    async def _raising_callback(_message: str) -> None:
+        raise RuntimeError("progress callback failed")
+
+    tracker = acp_runner.ACPProgressTracker(callback=_raising_callback)
+    tracker.agent_buffer = "bounded progress."
+    asyncio.run(tracker.flush())
+
+    assert tracker.agent_buffer == ""
+    assert tracker.last_emitted == "bounded progress."
+
+
+def test_run_node_flush_exception_does_not_skip_cleanup(
+    config: HarnessConfig,
+    project_setup,
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = Task(id="w-flush-failure", type="work", body="b", targets=[], skill="s")
+    spawn_ts = "attempt-flush-failure"
+    _prepare_runtime_identity(project_setup, workspace, task, spawn_ts)
+    handoff_path = project_setup.attempt_path("p1", "mission-001", spawn_ts, task.id)
+    monkeypatch.setenv("ZENITH_HANDOFF_PATH", str(handoff_path))
+    monkeypatch.setenv("ZENITH_NODE_ID", task.id)
+    monkeypatch.setenv("ZENITH_NODE_TYPE", task.type)
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+    mcp_processes: list[asyncio.subprocess.Process] = []
+    acp_processes: list[asyncio.subprocess.Process] = []
+    registrations: list[RuntimeIdentityRegistration] = []
+    original_spawn = asyncio.create_subprocess_shell
+    original_register = runner._register_runtime_identity
+
+    async def _no_op_server(*args, **kwargs):
+        process = await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        mcp_processes.append(process)
+        return process
+
+    async def _ready(*args, **kwargs):
+        return None
+
+    async def _spawn(*args, **kwargs):
+        process = await original_spawn(*args, **kwargs)
+        acp_processes.append(process)
+        return process
+
+    def _register(**kwargs):
+        registration = original_register(**kwargs)
+        registrations.append(registration)
+        return registration
+
+    async def _raise_flush(self) -> None:
+        raise RuntimeError("flush failed")
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    runner._register_runtime_identity = _register  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _spawn)
+    monkeypatch.setattr(acp_runner.ACPProgressTracker, "flush", _raise_flush)
+    try:
+        handoff = asyncio.run(
+            runner.run_node(
+                "p1",
+                "mission-001",
+                task,
+                spawn_ts,
+                project_setup,
+            )
+        )
+        assert handoff.done is True
+        assert mcp_processes[0].returncode is not None
+        assert acp_processes[0].returncode is not None
+        assert registrations[0].endpoint is None
+    finally:
+        for process in [*acp_processes, *mcp_processes]:
+            if process.returncode is None:
+                process.kill()
+
+
+@pytest.mark.parametrize("failure_point", ["prompt_render", "identity_registration"])
+def test_run_node_setup_failure_after_mcp_start_closes_mcp(
+    failure_point: str,
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = Task(
+        id=f"w-setup-{failure_point}",
+        type="work",
+        body="b",
+        targets=[],
+        skill="s",
+    )
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+    mcp_processes: list[asyncio.subprocess.Process] = []
+
+    async def _no_op_server(*args, **kwargs):
+        process = await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        mcp_processes.append(process)
+        return process
+
+    async def _ready(*args, **kwargs):
+        return None
+
+    def _raise_setup(*args, **kwargs):
+        raise RuntimeError(f"{failure_point} failed")
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    if failure_point == "prompt_render":
+        runner._render_prompts = _raise_setup  # type: ignore[method-assign]
+    else:
+        runner._register_runtime_identity = _raise_setup  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match=f"{failure_point} failed"):
+            asyncio.run(
+                runner.run_node(
+                    "p1",
+                    "mission-001",
+                    task,
+                    f"attempt-{failure_point}",
+                    project_setup,
+                )
+            )
+        assert mcp_processes[0].returncode is not None
+    finally:
+        for process in mcp_processes:
+            if process.returncode is None:
+                process.kill()
+
+
+def test_run_node_spawn_failure_cleanup_is_independent(
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = Task(id="w-spawn-cleanup", type="work", body="b", targets=[], skill="s")
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+    mcp_processes: list[asyncio.subprocess.Process] = []
+    close_attempted = False
+
+    class _ExplodingRegistration:
+        endpoint = "@endpoint"
+        capability = "capability"
+
+        def environment(self) -> dict[str, str]:
+            return {}
+
+        def close(self) -> None:
+            nonlocal close_attempted
+            close_attempted = True
+            raise RuntimeError("identity close failed")
+
+    async def _no_op_server(*args, **kwargs):
+        process = await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        mcp_processes.append(process)
+        return process
+
+    async def _ready(*args, **kwargs):
+        return None
+
+    async def _spawn_failure(*args, **kwargs):
+        raise RuntimeError("spawn failed")
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    runner._register_runtime_identity = lambda **kwargs: _ExplodingRegistration()  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _spawn_failure)
+    try:
+        with pytest.raises(RuntimeError, match="spawn failed"):
+            asyncio.run(
+                runner.run_node(
+                    "p1",
+                    "mission-001",
+                    task,
+                    "attempt-spawn-cleanup",
+                    project_setup,
+                )
+            )
+        assert close_attempted is True
+        assert mcp_processes[0].returncode is not None
+    finally:
+        for process in mcp_processes:
+            if process.returncode is None:
+                process.kill()
+
+
+def test_terminal_flush_exception_does_not_skip_cleanup(
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    terminal_config = replace(
+        config,
+        terminal_reviewer_provider_name="claude",
+        terminal_reviewer_acp_command=config.worker_acp_command,
+    )
+    runner = ACPNodeRunner(
+        config=terminal_config,
+        loader=AssetLoader(terminal_config),
+    )
+    mcp_processes: list[asyncio.subprocess.Process] = []
+    acp_processes: list[asyncio.subprocess.Process] = []
+    original_spawn = asyncio.create_subprocess_shell
+
+    async def _no_op_server(*args, **kwargs):
+        process = await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        mcp_processes.append(process)
+        return process
+
+    async def _ready(*args, **kwargs):
+        return None
+
+    async def _spawn(*args, **kwargs):
+        process = await original_spawn(*args, **kwargs)
+        acp_processes.append(process)
+        return process
+
+    async def _raise_flush(self) -> None:
+        raise RuntimeError("flush failed")
+
+    runner._start_terminal_reviewer_mcp = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _spawn)
+    monkeypatch.setattr(acp_runner.ACPProgressTracker, "flush", _raise_flush)
+    try:
+        with pytest.raises(RuntimeError, match="without calling"):
+            asyncio.run(
+                runner.run_terminal_review(
+                    "p1",
+                    "mission-001",
+                    "attempt-flush-failure",
+                    project_setup,
+                )
+            )
+        assert mcp_processes[0].returncode is not None
+        assert acp_processes[0].returncode is not None
+    finally:
+        for process in [*acp_processes, *mcp_processes]:
+            if process.returncode is None:
+                process.kill()
+
+
+def test_run_node_stderr_tail_is_bounded_under_multimegabyte_output(
+    config: HarnessConfig,
+    project_setup,
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = Task(id="w-stderr-ring", type="work", body="b", targets=[], skill="s")
+    spawn_ts = "attempt-stderr-ring"
+    _prepare_runtime_identity(project_setup, workspace, task, spawn_ts)
+    handoff_path = project_setup.attempt_path("p1", "mission-001", spawn_ts, task.id)
+    monkeypatch.setenv("ZENITH_HANDOFF_PATH", str(handoff_path))
+    monkeypatch.setenv("ZENITH_NODE_ID", task.id)
+    monkeypatch.setenv("ZENITH_NODE_TYPE", task.type)
+    monkeypatch.setenv("MOCK_ACP_STDERR_BYTES", str(3 * 1024 * 1024))
+    runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+    captured_tails: list[str] = []
+    original_drain = acp_runner._drain_stream_chunks
+
+    async def _recording_drain(stream):
+        result = await original_drain(stream)
+        captured_tails.append(result)
+        return result
+
+    async def _no_op_server(*args, **kwargs):
+        return await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def _ready(*args, **kwargs):
+        return None
+
+    runner._start_worker_mcp_server = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    monkeypatch.setattr(acp_runner, "_drain_stream_chunks", _recording_drain)
+    handoff = asyncio.run(
+        runner.run_node(
+            "p1",
+            "mission-001",
+            task,
+            spawn_ts,
+            project_setup,
+        )
+    )
+
+    assert handoff.done is True
+    assert len(captured_tails) == 1
+    assert len(captured_tails[0].encode()) <= acp_runner.ACP_STDERR_TAIL_BYTES
+
+
+def test_terminal_stderr_tail_is_bounded_under_multimegabyte_output(
+    config: HarnessConfig,
+    project_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    terminal_config = replace(
+        config,
+        terminal_reviewer_provider_name="claude",
+        terminal_reviewer_acp_command=config.worker_acp_command,
+    )
+    runner = ACPNodeRunner(
+        config=terminal_config,
+        loader=AssetLoader(terminal_config),
+    )
+    monkeypatch.setenv("MOCK_ACP_STDERR_BYTES", str(3 * 1024 * 1024))
+    captured_tails: list[str] = []
+    original_drain = acp_runner._drain_stream_chunks
+
+    async def _recording_drain(stream):
+        result = await original_drain(stream)
+        captured_tails.append(result)
+        return result
+
+    async def _no_op_server(*args, **kwargs):
+        return await asyncio.create_subprocess_exec(
+            "sleep",
+            "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def _ready(*args, **kwargs):
+        return None
+
+    runner._start_terminal_reviewer_mcp = _no_op_server  # type: ignore[method-assign]
+    runner._wait_for_server_ready = _ready  # type: ignore[method-assign]
+    monkeypatch.setattr(acp_runner, "_drain_stream_chunks", _recording_drain)
+    with pytest.raises(RuntimeError, match="without calling"):
+        asyncio.run(
+            runner.run_terminal_review(
+                "p1",
+                "mission-001",
+                "attempt-stderr-ring",
+                project_setup,
+            )
+        )
+
+    assert len(captured_tails) == 1
+    assert len(captured_tails[0].encode()) <= acp_runner.ACP_STDERR_TAIL_BYTES
 
 
 def test_attempt_path_naming(config: HarnessConfig, project_setup):

--- a/zenith/tests/test_coordinator.py
+++ b/zenith/tests/test_coordinator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from zenith_harness.config import HarnessConfig
+from zenith_harness.coordinator import MissionCoordinator
 from zenith_harness.controller import ProjectController, ToolError
 from zenith_harness.dispatcher import (
     DispatchRequest,
@@ -346,6 +347,41 @@ class TestValidatorDissentFailsGate:
         report = items[0].report
         assert "v-scrutiny: 1/1 passed" in report
         assert "v-user-surface: 1/1 passed" in report
+
+    def test_replacement_gate_ignores_validators_behind_current_validators(self) -> None:
+        task_list = TaskList(
+            tasks=[
+                _task("w-old", "work", ["VAL-001"]),
+                _task("v-old", "validate", ["VAL-001"], depends_on=["w-old"]),
+                _task("w-new", "work", ["VAL-001"], depends_on=["v-old"]),
+                _task("v-new", "validate", ["VAL-001"], depends_on=["w-new"]),
+                _task("g-new", "gate", ["VAL-001"], depends_on=["v-new"]),
+            ]
+        )
+        coordinator = MissionCoordinator.__new__(MissionCoordinator)
+
+        assert coordinator._upstream_validators(task_list, "g-new") == ["v-new"]
+
+        branched = TaskList(
+            tasks=[
+                _task("w-old", "work", ["VAL-001"]),
+                _task("v-old", "validate", ["VAL-001"], depends_on=["w-old"]),
+                _task("w-left", "work", ["VAL-001"], depends_on=["v-old"]),
+                _task("w-right", "work", ["VAL-001"], depends_on=["v-old"]),
+                _task("v-left", "validate", ["VAL-001"], depends_on=["w-left"]),
+                _task("v-right", "validate", ["VAL-001"], depends_on=["w-right"]),
+                _task(
+                    "g-new",
+                    "gate",
+                    ["VAL-001"],
+                    depends_on=["v-left", "v-right"],
+                ),
+            ]
+        )
+        assert set(coordinator._upstream_validators(branched, "g-new")) == {
+            "v-left",
+            "v-right",
+        }
 
     def test_validator_omitting_items_fails_gate(
         self, config: HarnessConfig, workspace: Path

--- a/zenith/tests/test_server_wave_lock.py
+++ b/zenith/tests/test_server_wave_lock.py
@@ -1,0 +1,114 @@
+"""Regression tests for the per-project wave flock (`_run_project_locked`).
+
+Proves the fix for the concurrent-wave disk race: an advisory lock whose
+lifetime is tied to the worker THREAD (not the async request) so that an
+aborted `advance_project` cannot let a retried call run concurrently and stub
+still-in-flight validators. See server.py `_run_project_locked`.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+from zenith_harness.config import HarnessConfig
+from zenith_harness.controller import ToolError
+from zenith_harness.server import _run_project_locked
+
+PID = "proj-1"
+
+
+@pytest.fixture
+def controller(harness_home: Path):
+    bundled = Path(__file__).resolve().parents[1] / "src" / "zenith_harness" / "bundled"
+    cfg = HarnessConfig(
+        bundled_dir=bundled,
+        harness_home=harness_home,
+        projects_dir=harness_home / "projects",
+        orchestrator_provider_name="claude",
+        worker_provider_name="claude",
+        worker_acp_command=None,
+        validator_provider_name=None,
+        validator_acp_command=None,
+        terminal_reviewer_provider_name=None,
+        terminal_reviewer_acp_command=None,
+    )
+    # The helper only touches controller.config.zenith_runtime_dir(pid).
+    return types.SimpleNamespace(config=cfg)
+
+
+def test_runs_fn_and_returns_result(controller):
+    assert _run_project_locked(controller, PID, lambda a, b: a + b, 2, 3) == 5
+    assert (controller.config.zenith_runtime_dir(PID) / ".wave.lock").exists()
+
+
+def test_second_call_is_rejected_while_first_holds_lock(controller):
+    started, release = threading.Event(), threading.Event()
+
+    def slow():
+        started.set()
+        release.wait(5)
+        return "first"
+
+    t = threading.Thread(target=lambda: _run_project_locked(controller, PID, slow))
+    t.start()
+    assert started.wait(5)
+    try:
+        with pytest.raises(ToolError) as ei:
+            _run_project_locked(controller, PID, lambda: "second")
+        assert ei.value.code == "wave_in_progress"
+    finally:
+        release.set()
+        t.join(5)
+    # lock freed after the holder returns
+    assert _run_project_locked(controller, PID, lambda: "third") == "third"
+
+
+def test_lock_survives_async_cancellation(controller):
+    """The exact bug: aborting the MCP request must NOT free the wave lock while
+    the orphaned worker thread keeps running."""
+
+    async def scenario():
+        started, release = threading.Event(), threading.Event()
+
+        def slow():
+            started.set()
+            release.wait(5)
+            return "done"
+
+        task = asyncio.create_task(
+            asyncio.to_thread(_run_project_locked, controller, PID, slow)
+        )
+        await asyncio.to_thread(started.wait, 5)  # thread now in critical section
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # async request is gone, but the thread still runs and still holds the lock
+        with pytest.raises(ToolError) as ei:
+            _run_project_locked(controller, PID, lambda: "x")
+        assert ei.value.code == "wave_in_progress"
+
+        # let the orphaned wave finish; the lock frees only then
+        release.set()
+        for _ in range(50):
+            await asyncio.to_thread(time.sleep, 0.05)
+            try:
+                assert _run_project_locked(controller, PID, lambda: "ok") == "ok"
+                return
+            except ToolError:
+                continue
+        pytest.fail("lock never released after the wave completed")
+
+    asyncio.run(scenario())
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/zenith/tests/test_server_wave_lock.py
+++ b/zenith/tests/test_server_wave_lock.py
@@ -18,6 +18,7 @@ import pytest
 from zenith_harness.config import HarnessConfig
 from zenith_harness.controller import ToolError
 from zenith_harness.server import _run_project_locked
+from zenith_harness.storage import ProjectStore
 
 PID = "proj-1"
 
@@ -37,13 +38,51 @@ def controller(harness_home: Path):
         terminal_reviewer_provider_name=None,
         terminal_reviewer_acp_command=None,
     )
-    # The helper only touches controller.config.zenith_runtime_dir(pid).
-    return types.SimpleNamespace(config=cfg)
+    return types.SimpleNamespace(config=cfg, store=ProjectStore(cfg))
 
 
 def test_runs_fn_and_returns_result(controller):
     assert _run_project_locked(controller, PID, lambda a, b: a + b, 2, 3) == 5
-    assert (controller.config.zenith_runtime_dir(PID) / ".wave.lock").exists()
+    assert (controller.store.zenith_runtime_dir(PID) / ".wave.lock").exists()
+
+
+def test_rejects_project_id_that_escapes_projects_dir(controller):
+    called = False
+
+    def operation():
+        nonlocal called
+        called = True
+
+    with pytest.raises(ValueError, match="invalid project_id"):
+        _run_project_locked(controller, "../escape", operation)
+
+    assert not called
+    assert not (controller.config.projects_dir.parent / "escape").exists()
+
+
+@pytest.mark.parametrize("dangling", [False, True])
+def test_rejects_symlinked_wave_lock(controller, tmp_path, dangling):
+    runtime = controller.store.zenith_runtime_dir(PID)
+    runtime.mkdir(parents=True)
+    outside = tmp_path / "outside-lock"
+    if not dangling:
+        outside.write_text("keep\n")
+    (runtime / ".wave.lock").symlink_to(outside)
+    called = False
+
+    def operation():
+        nonlocal called
+        called = True
+
+    with pytest.raises(ToolError) as exc_info:
+        _run_project_locked(controller, PID, operation)
+
+    assert exc_info.value.code == "unsafe_wave_lock"
+    assert not called
+    if dangling:
+        assert not outside.exists()
+    else:
+        assert outside.read_text() == "keep\n"
 
 
 def test_second_call_is_rejected_while_first_holds_lock(controller):

--- a/zenith/tests/test_storage.py
+++ b/zenith/tests/test_storage.py
@@ -120,6 +120,214 @@ class TestProjectLifecycle:
         )
         assert (skills_dir / "scrutiny-validator" / "SKILL.md").exists()
 
+    def test_relative_symlinked_workspace_skill_is_materialized(
+        self, store: ProjectStore, workspace: Path
+    ) -> None:
+        source = workspace / "shared-skills" / "shared-skill" / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text("# Shared skill\n")
+        linked = workspace / ".agents" / "skills" / "shared-skill"
+        linked.parent.mkdir(parents=True)
+        linked.symlink_to(Path("../../shared-skills/shared-skill"))
+        imported = store.zenith_dir("p1") / "skills" / "shared-skill"
+        imported.parent.mkdir(parents=True)
+        imported.symlink_to(Path("../missing-shared-skill"))
+
+        store.create_project("brief", workspace, project_id="p1")
+
+        assert imported.is_dir()
+        assert not imported.is_symlink()
+        assert (imported / "SKILL.md").read_text() == "# Shared skill\n"
+
+        store.create_project("brief", workspace, project_id="p1")
+        assert (imported / "SKILL.md").read_text() == "# Shared skill\n"
+
+    @pytest.mark.parametrize("kind", ["file", "directory", "dangling", "cycle"])
+    def test_out_of_workspace_skill_symlink_is_not_imported(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path, kind: str
+    ) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        linked = workspace / ".agents" / "skills" / "external-skill"
+        linked.parent.mkdir(parents=True)
+        if kind == "file":
+            target = outside / "SKILL.md"
+            target.write_text("private\n")
+        elif kind == "directory":
+            target = outside / "external-skill"
+            target.mkdir()
+            (target / "SKILL.md").write_text("private\n")
+        elif kind == "dangling":
+            target = outside / "missing"
+        else:
+            target = outside / "cycle"
+            target.symlink_to(target)
+        linked.symlink_to(target)
+
+        store.create_project("brief", workspace, project_id="p1")
+
+        assert not (store.zenith_dir("p1") / "skills" / "external-skill").exists()
+
+    def test_nested_external_and_cyclic_skill_links_are_skipped(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        source = workspace / "shared-skills" / "shared-skill"
+        source.mkdir(parents=True)
+        (source / "SKILL.md").write_text("# Shared skill\n")
+        outside = tmp_path / "outside-secret"
+        outside.write_text("private\n")
+        (source / "external").symlink_to(outside)
+        (source / "cycle").symlink_to(source)
+        linked = workspace / ".agents" / "skills" / "shared-skill"
+        linked.parent.mkdir(parents=True)
+        linked.symlink_to(Path("../../shared-skills/shared-skill"))
+
+        store.create_project("brief", workspace, project_id="p1")
+
+        imported = store.zenith_dir("p1") / "skills" / "shared-skill"
+        assert (imported / "SKILL.md").read_text() == "# Shared skill\n"
+        assert not (imported / "external").exists()
+        assert not (imported / "cycle").exists()
+
+    def test_symlinked_host_directory_is_ignored(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        outside_host = tmp_path / "outside-agent"
+        skill = outside_host / "skills" / "external-skill" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("private\n")
+        (workspace / ".agents").symlink_to(outside_host)
+
+        store.create_project("brief", workspace, project_id="p1")
+
+        imported = store.zenith_dir("p1") / "skills" / "external-skill"
+        assert not imported.exists()
+        assert list((outside_host / "skills").iterdir()) == [skill.parent]
+
+    def test_existing_destination_symlink_cannot_redirect_skill_copy(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        source = workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text("# Shared skill\n")
+        outside = tmp_path / "outside-destination"
+        outside.mkdir()
+        imported = store.zenith_dir("p1") / "skills" / "shared-skill"
+        imported.parent.mkdir(parents=True)
+        imported.symlink_to(outside)
+
+        store.create_project("brief", workspace, project_id="p1")
+
+        assert imported.is_dir()
+        assert not imported.is_symlink()
+        assert (imported / "SKILL.md").read_text() == "# Shared skill\n"
+        assert not (outside / "SKILL.md").exists()
+
+    def test_destination_root_symlink_is_replaced_before_skill_copy(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        source = workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text("# Shared skill\n")
+        outside = tmp_path / "outside-root"
+        outside.mkdir()
+        skills_root = store.zenith_dir("p1") / "skills"
+        skills_root.parent.mkdir(parents=True)
+        skills_root.symlink_to(outside)
+
+        store.create_project("brief", workspace, project_id="p1")
+
+        assert skills_root.is_dir()
+        assert not skills_root.is_symlink()
+        assert (skills_root / "shared-skill" / "SKILL.md").read_text() == (
+            "# Shared skill\n"
+        )
+        assert not (outside / "shared-skill").exists()
+
+    def test_sync_replaces_destination_root_symlink(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        store.create_project("brief", workspace, project_id="p1")
+        skills_root = store.zenith_dir("p1") / "skills"
+        parked = skills_root.with_name("skills-parked")
+        skills_root.rename(parked)
+        outside = tmp_path / "outside-sync-root"
+        outside.mkdir()
+        skills_root.symlink_to(outside)
+
+        store.sync_workspace_skill_surfaces("p1")
+
+        assert skills_root.is_dir()
+        assert not skills_root.is_symlink()
+        assert not any(outside.iterdir())
+
+    def test_create_rejects_symlinked_project_bucket(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        projects = store.config.projects_dir
+        projects.mkdir(parents=True)
+        outside = tmp_path / "outside-project"
+        outside.mkdir()
+        (projects / "p1").symlink_to(outside)
+
+        with pytest.raises(ValueError, match="symlinked project path"):
+            store.create_project("brief", workspace, project_id="p1")
+
+        assert not any(outside.iterdir())
+
+    def test_sync_rejects_symlinked_zenith_directory(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        store.create_project("brief", workspace, project_id="p1")
+        zenith = store.zenith_dir("p1")
+        zenith.rename(zenith.with_name(".zenith-parked"))
+        outside = tmp_path / "outside-zenith"
+        outside.mkdir()
+        zenith.symlink_to(outside)
+
+        with pytest.raises(ValueError, match="symlinked project path"):
+            store.sync_workspace_skill_surfaces("p1")
+
+        assert not any(outside.iterdir())
+
+    def test_sync_replaces_bundled_skill_directory_symlink(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        store.create_project("brief", workspace, project_id="p1")
+        skill_dir = store.zenith_dir("p1") / "skills" / "scrutiny-validator"
+        parked = skill_dir.with_name("scrutiny-validator-parked")
+        skill_dir.rename(parked)
+        outside = tmp_path / "outside-skill"
+        outside.mkdir()
+        skill_dir.symlink_to(outside)
+
+        store.sync_workspace_skill_surfaces("p1")
+
+        assert skill_dir.is_dir()
+        assert not skill_dir.is_symlink()
+        assert (skill_dir / "SKILL.md").is_file()
+        assert not (outside / "SKILL.md").exists()
+
+    def test_sync_replaces_bundled_skill_file_symlink(
+        self, store: ProjectStore, workspace: Path, tmp_path: Path
+    ) -> None:
+        store.create_project("brief", workspace, project_id="p1")
+        skill_file = (
+            store.zenith_dir("p1")
+            / "skills"
+            / "scrutiny-validator"
+            / "SKILL.md"
+        )
+        skill_file.unlink()
+        outside = tmp_path / "outside-SKILL.md"
+        skill_file.symlink_to(outside)
+
+        store.sync_workspace_skill_surfaces("p1")
+
+        assert skill_file.is_file()
+        assert not skill_file.is_symlink()
+        assert not outside.exists()
+
     def test_sync_workspace_skill_surfaces_updates_preserved_host_dir(
         self, store: ProjectStore, workspace: Path
     ) -> None:


### PR DESCRIPTION
# fix(server): hold the per-project wave lock in the worker thread, not the async request

## Problem

`advance_project` (and the other mutating tools) run the controller call synchronously via
`asyncio.to_thread`, guarded by an in-process `asyncio.Lock` (`server.py:103-119`). A running
thread's future cannot be cancelled. When the MCP request is aborted — a user interrupt or the
client's idle-abort — the awaiting coroutine is cancelled and the `asyncio.Lock` releases, but
the wave thread keeps running `controller.advance_project`'s `while True: coordinator.step()`
loop to completion, now mutating on-disk state (`task-state.json`, `attempts/*.json`) **without
holding any lock**.

If the caller then retries `advance_project`, two waves run concurrently on the same project.
The new wave's `_reconcile_pending_attempts` finds the validator still `running` with no attempt
file yet and writes an empty stub (`cleared`, `passed=false`, `items=[]`); the gate evaluates
that stub, fails every target as `missing`, and goes terminal-`failed`. The original wave then
finishes and silently overwrites the attempt file with the real (passing) verdicts — too late,
the gate is already failed and needs a manual patch to recover.

The existing comment at `server.py:103-108` already flags concurrent same-project operations as
undefined behavior; this is that race, reachable through ordinary request cancellation.

## Fix

Add `_run_project_locked`, wrapping every mutating controller call with an advisory `flock`
acquired **inside** the `to_thread` target and released only when the call returns. Because the
lock lives on the worker thread, async cancellation of the request can no longer free it while
the wave is still running. A concurrent same-project mutating call gets a typed
`wave_in_progress` ToolError instead of racing on disk. The in-process `asyncio.Lock` is kept as
first-line serialization.

Scope: `submit_plan`, `advance_project`, `end_mission`, `decide_attention`, `abort_project`.
`start_project` (no project id yet) and `inspect_project` (read-only) are unchanged.

## Tests

`tests/test_server_wave_lock.py`:
- runs the wrapped fn and returns its result;
- a second same-project call is rejected with `wave_in_progress` while the first holds the lock;
- **`test_lock_survives_async_cancellation`** — cancels the awaiting task and asserts the
  orphaned thread still holds the lock (concurrent call → `wave_in_progress`) until the wave
  actually completes, then the lock frees. This is the regression for the reported race.

Full suite: 205 passed, 7 skipped.

## Notes

`flock` is POSIX advisory locking (Linux/macOS). If Windows support is required, this can fall
back to a lockfile-with-pid or `msvcrt.locking`; happy to adjust to the project's platform
policy.
