### PR TITLE
fix(cli): wire --terminal-reviewer-provider/acp-command through to config

### DIFF
--- a/zenith/src/zenith_harness/cli.py
+++ b/zenith/src/zenith_harness/cli.py
@@ -319,6 +319,8 @@ def _resolve_selection(
         validation_worker=get_provider(validator) if validator else None,
         worker_acp_command=worker_acp_command,
         validation_worker_acp_command=validator_acp_command,
+        terminal_reviewer=get_provider(terminal_reviewer) if terminal_reviewer else None,
+        terminal_reviewer_acp_command=terminal_reviewer_acp_command,
     )
 
 

--- a/zenith/src/zenith_harness/config.py
+++ b/zenith/src/zenith_harness/config.py
@@ -194,6 +194,12 @@ class HarnessConfig:
             ),
             worker_acp_command=self.worker_acp_command,
             validation_worker_acp_command=self.validator_acp_command,
+            terminal_reviewer=(
+                self.terminal_reviewer_provider
+                if self.terminal_reviewer_provider_name
+                else None
+            ),
+            terminal_reviewer_acp_command=self.terminal_reviewer_acp_command,
         )
 
     # ------------------------------------------------------------------

--- a/zenith/src/zenith_harness/providers.py
+++ b/zenith/src/zenith_harness/providers.py
@@ -38,6 +38,8 @@ class ProviderSelection:
     validation_worker: ProviderDefinition | None = None
     worker_acp_command: str | None = None
     validation_worker_acp_command: str | None = None
+    terminal_reviewer: ProviderDefinition | None = None
+    terminal_reviewer_acp_command: str | None = None
 
     @property
     def resolved_worker_acp_command(self) -> str | None:
@@ -61,6 +63,24 @@ class ProviderSelection:
             or self.resolved_validation_worker.default_worker_acp_command
         )
 
+    @property
+    def resolved_terminal_reviewer(self) -> ProviderDefinition:
+        return self.terminal_reviewer or self.resolved_validation_worker
+
+    @property
+    def resolved_terminal_reviewer_acp_command(self) -> str | None:
+        if self.terminal_reviewer_acp_command:
+            return self.terminal_reviewer_acp_command
+        if self.resolved_terminal_reviewer.name != self.resolved_validation_worker.name:
+            return (
+                self.resolved_terminal_reviewer.default_worker_acp_command
+                or self.resolved_validation_worker_acp_command
+            )
+        return (
+            self.resolved_validation_worker_acp_command
+            or self.resolved_terminal_reviewer.default_worker_acp_command
+        )
+
     def env(self) -> dict[str, str]:
         env: dict[str, str] = {
             "ZENITH_ORCHESTRATOR_PROVIDER": self.orchestrator.name,
@@ -76,6 +96,14 @@ class ProviderSelection:
             and validation_command is not None
         ):
             env["ZENITH_VALIDATOR_ACP_COMMAND"] = validation_command
+        if self.resolved_terminal_reviewer.name != self.resolved_validation_worker.name:
+            env["ZENITH_TERMINAL_REVIEWER_PROVIDER"] = self.resolved_terminal_reviewer.name
+        tr_command = self.resolved_terminal_reviewer_acp_command
+        if (
+            tr_command != self.resolved_validation_worker_acp_command
+            and tr_command is not None
+        ):
+            env["ZENITH_TERMINAL_REVIEWER_ACP_COMMAND"] = tr_command
         return env
 
     def skill_install_dirs(self) -> tuple[str, ...]:
@@ -83,6 +111,7 @@ class ProviderSelection:
             self.orchestrator.skill_dirs
             + self.worker.skill_dirs
             + self.resolved_validation_worker.skill_dirs
+            + self.resolved_terminal_reviewer.skill_dirs
         )
 
     def skill_alias_dirs(self) -> tuple[str, ...]:
@@ -90,6 +119,7 @@ class ProviderSelection:
             self.orchestrator.skill_alias_dirs
             + self.worker.skill_alias_dirs
             + self.resolved_validation_worker.skill_alias_dirs
+            + self.resolved_terminal_reviewer.skill_alias_dirs
         )
 
     def providers(self) -> tuple[ProviderDefinition, ...]:
@@ -97,6 +127,7 @@ class ProviderSelection:
             self.orchestrator,
             self.worker,
             self.resolved_validation_worker,
+            self.resolved_terminal_reviewer,
         )
         ordered: list[ProviderDefinition] = []
         seen: set[str] = set()

--- a/zenith/tests/test_cli.py
+++ b/zenith/tests/test_cli.py
@@ -288,6 +288,69 @@ class TestInit:
         assert mcp_env["ZAI_API_KEY"] == "zai-test-key"
         assert "DATABASE_URL" not in mcp_env
 
+    def test_claude_init_writes_terminal_reviewer_env_names(
+        self, runner: CliRunner, workspace: Path, env: dict[str, str]
+    ) -> None:
+        r = runner.invoke(
+            cli,
+            [
+                "init",
+                "--workspace-dir",
+                str(workspace),
+                "--agent",
+                "claude",
+                "--terminal-reviewer-provider",
+                "codex",
+                "--terminal-reviewer-acp-command",
+                "custom-tr-acp",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+
+        mcp = json.loads((workspace / ".mcp.json").read_text())
+        mcp_env = mcp["mcpServers"]["zenith"]["env"]
+        assert mcp_env["ZENITH_TERMINAL_REVIEWER_PROVIDER"] == "codex"
+        assert mcp_env["ZENITH_TERMINAL_REVIEWER_ACP_COMMAND"] == "custom-tr-acp"
+
+    def test_claude_init_omits_terminal_reviewer_env_when_unset(
+        self, runner: CliRunner, workspace: Path, env: dict[str, str]
+    ) -> None:
+        r = runner.invoke(
+            cli, ["init", "--workspace-dir", str(workspace), "--agent", "claude"]
+        )
+        assert r.exit_code == 0, r.output
+
+        mcp = json.loads((workspace / ".mcp.json").read_text())
+        mcp_env = mcp["mcpServers"]["zenith"]["env"]
+        assert "ZENITH_TERMINAL_REVIEWER_PROVIDER" not in mcp_env
+        assert "ZENITH_TERMINAL_REVIEWER_ACP_COMMAND" not in mcp_env
+
+    def test_three_distinct_providers_all_env_written(
+        self, runner: CliRunner, workspace: Path, env: dict[str, str]
+    ) -> None:
+        r = runner.invoke(
+            cli,
+            [
+                "init",
+                "--workspace-dir",
+                str(workspace),
+                "--agent",
+                "claude",
+                "--validator-provider",
+                "codex",
+                "--terminal-reviewer-provider",
+                "hermes",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+
+        mcp = json.loads((workspace / ".mcp.json").read_text())
+        mcp_env = mcp["mcpServers"]["zenith"]["env"]
+        assert mcp_env["ZENITH_ORCHESTRATOR_PROVIDER"] == "claude"
+        assert mcp_env["ZENITH_WORKER_PROVIDER"] == "claude"
+        assert mcp_env["ZENITH_VALIDATOR_PROVIDER"] == "codex"
+        assert mcp_env["ZENITH_TERMINAL_REVIEWER_PROVIDER"] == "hermes"
+
 
 class TestListProjects:
     def test_empty(self, runner: CliRunner, env: dict[str, str]) -> None:

--- a/zenith/tests/test_config.py
+++ b/zenith/tests/test_config.py
@@ -6,6 +6,31 @@ from pathlib import Path
 import pytest
 
 from zenith_harness.config import HarnessConfig
+from zenith_harness.providers import ProviderSelection, get_provider
+
+_PROVIDER_ENV_KEYS = (
+    "ZENITH_ORCHESTRATOR_PROVIDER",
+    "ZENITH_WORKER_PROVIDER",
+    "ZENITH_WORKER_ACP_COMMAND",
+    "ZENITH_VALIDATOR_PROVIDER",
+    "ZENITH_VALIDATOR_ACP_COMMAND",
+    "ZENITH_TERMINAL_REVIEWER_PROVIDER",
+    "ZENITH_TERMINAL_REVIEWER_ACP_COMMAND",
+)
+
+
+def _apply_selection_env(
+    monkeypatch, harness_home: Path, selection: ProviderSelection
+) -> HarnessConfig:
+    """Write selection.env() to a clean environment and re-discover from it."""
+    monkeypatch.setenv("ZENITH_HOME", str(harness_home))
+    monkeypatch.delenv("ZENITH_PROJECT_BUCKET_DIR", raising=False)
+    for key in _PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in selection.env().items():
+        monkeypatch.setenv(key, value)
+    return HarnessConfig.discover()
+
 
 _EFFORT_ENV_VARS = (
     "ZENITH_WORKER_REASONING_EFFORT",
@@ -140,3 +165,44 @@ def test_for_role_reasoning_effort_explicit_override_wins(
     assert config.for_role("validator").worker_reasoning_effort == "low"
     # terminal_reviewer falls back to the validator setting first.
     assert config.for_role("terminal_reviewer").worker_reasoning_effort == "low"
+
+
+def test_terminal_reviewer_selection_round_trips_through_env(
+    monkeypatch,
+    harness_home: Path,
+) -> None:
+    """A distinct terminal reviewer written by env() is read back intact."""
+    selection = ProviderSelection(
+        orchestrator=get_provider("claude"),
+        worker=get_provider("claude"),
+        terminal_reviewer=get_provider("codex"),
+        terminal_reviewer_acp_command="custom-tr-acp",
+    )
+
+    config = _apply_selection_env(monkeypatch, harness_home, selection)
+
+    assert config.terminal_reviewer_provider.name == "codex"
+    assert config.resolved_terminal_reviewer_acp_command == "custom-tr-acp"
+
+
+def test_terminal_reviewer_cascades_to_validator_after_round_trip(
+    monkeypatch,
+    harness_home: Path,
+) -> None:
+    """With no explicit terminal reviewer, discover() falls back to the validator.
+
+    env() omits the terminal-reviewer vars because they match the validator
+    (the cascade parent); the read side must reconstruct the same resolution.
+    """
+    selection = ProviderSelection(
+        orchestrator=get_provider("claude"),
+        worker=get_provider("claude"),
+        validation_worker=get_provider("codex"),
+    )
+
+    assert "ZENITH_TERMINAL_REVIEWER_PROVIDER" not in selection.env()
+
+    config = _apply_selection_env(monkeypatch, harness_home, selection)
+
+    assert config.terminal_reviewer_provider_name is None
+    assert config.terminal_reviewer_provider.name == "codex"


### PR DESCRIPTION
## Problem

The `--terminal-reviewer-provider` and `--terminal-reviewer-acp-command` flags were accepted by click but silently dropped in `_resolve_selection`: `ProviderSelection` had no `terminal_reviewer` fields, so the values never reached `env()` and were never written to `.mcp.json` or `.codex/config.toml`.

`HarnessConfig` already reads `ZENITH_TERMINAL_REVIEWER_PROVIDER` and `ZENITH_TERMINAL_REVIEWER_ACP_COMMAND` with a full `terminal_reviewer -> validator -> worker` cascade — only the write side was broken.

## Fix

- Add `terminal_reviewer` and `terminal_reviewer_acp_command` fields to `ProviderSelection`, with `resolved_terminal_reviewer` / `resolved_terminal_reviewer_acp_command` properties mirroring the existing `validation_worker` pattern.
- Update `env()` to emit the terminal-reviewer vars only when they differ from the validator's (the cascade parent), matching how the validator compares against the worker.
- Include the terminal reviewer in `providers()` and the skill dirs so its assets get installed when it's a distinct provider.

## Tests

- terminal-reviewer provider + acp-command land in `.mcp.json` env.
- unset flags emit no terminal-reviewer env keys (cascade handles it).
- three distinct providers (claude/codex/hermes) all write their env vars in a single init.
- round-trip: a distinct terminal reviewer written by `env()` is read back intact by `HarnessConfig.discover()`.
- round-trip: with no explicit terminal reviewer, `env()` omits the vars and `discover()` reconstructs the validator as the cascade fallback.

All three CI checks pass locally: `ruff check .`, `mypy src`, `pytest -q` (207 passed, 7 skipped).

> Note: issue creation is restricted on this repo, so per CONTRIBUTING.md's fallback for small fixes this PR is filed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)