### PR TITLE
fix(acp): route codex -c overrides through CODEX_CONFIG for npm adapter

### DIFF
--- a/zenith/src/zenith_harness/acp_runner.py
+++ b/zenith/src/zenith_harness/acp_runner.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -118,13 +119,46 @@ def _augment_acp_command(
     return command
 
 
-def _acp_subprocess_env(provider) -> dict[str, str]:
+_CODEX_C_OVERRIDE_RE = re.compile(r'-c\s+(\w+)=["\']([^"\']*)["\']')
+
+
+def _parse_codex_c_overrides(command: str) -> dict[str, str]:
+    """Extract -c key="value" overrides from a codex-acp command string.
+
+    Both _augment_acp_command and user-supplied ZENITH_*_ACP_COMMAND values
+    splice config via `-c key="value"`. The npm codex-acp adapter ignores
+    argv `-c` flags (issue #27), so we re-route them into CODEX_CONFIG.
+    """
+    return dict(_CODEX_C_OVERRIDE_RE.findall(command))
+
+
+def _acp_subprocess_env(
+    provider,
+    reasoning_effort: str | None = None,
+    acp_command: str | None = None,
+) -> dict[str, str]:
     """Build the env handed to an ACP-agent subprocess.
 
     For codex we preserve PATH so node-based ACP adapters can launch via
-    `/usr/bin/env node`, and pass sandbox-disable hints through env. The
-    command line also receives `sandbox_mode="danger-full-access"` in
-    `_augment_acp_command`.
+    `/usr/bin/env node`, and pass sandbox-disable hints through env.
+
+    The npm `@agentclientprotocol/codex-acp` adapter (v1.1.0) does not
+    parse `-c` overrides from argv — it reads configuration from the
+    `CODEX_CONFIG` env var (JSON). We build it here in three layers,
+    each overriding the previous:
+
+    1. User-supplied `CODEX_CONFIG` (ambient env, e.g. `{"model": "..."}`).
+    2. `-c` overrides parsed from the augmented command string — these
+       include the user's custom model from `ZENITH_*_ACP_COMMAND` and
+       the sandbox/approval/effort flags appended by
+       `_augment_acp_command`.
+    3. Zenith's three safety keys (`sandbox_mode`, `approval_policy`,
+       `model_reasoning_effort`) — always win, since sandbox/approval
+       are autonomy-safety requirements and effort is the per-role
+       resolved value.
+
+    The `-c` flags remain in argv for `-c`-honoring codex-acp builds
+    (harmless if ignored by the npm adapter).
 
     For hermes the env is passed through unchanged.
     """
@@ -134,6 +168,30 @@ def _acp_subprocess_env(provider) -> dict[str, str]:
         # Env-var hints — harmless if codex ignores them.
         env["CODEX_SANDBOX"] = "danger-full-access"
         env["CODEX_DISABLE_SANDBOX"] = "1"
+        # The npm codex-acp adapter reads CODEX_CONFIG (JSON) for its
+        # configuration, not argv `-c` overrides. Build it in three
+        # layers so the user's custom model (from the command string)
+        # is preserved alongside zenith's safety config.
+        effort = reasoning_effort or "xhigh"
+        codex_config: dict[str, Any] = {}
+        # Layer 1: user-supplied CODEX_CONFIG.
+        existing = env.get("CODEX_CONFIG")
+        if existing:
+            try:
+                parsed = json.loads(existing)
+                if isinstance(parsed, dict):
+                    codex_config = parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+        # Layer 2: -c overrides from the augmented command string
+        # (carries the user's custom model + zenith's -c flags).
+        if acp_command:
+            codex_config.update(_parse_codex_c_overrides(acp_command))
+        # Layer 3: zenith's safety keys always win.
+        codex_config["sandbox_mode"] = "danger-full-access"
+        codex_config["approval_policy"] = "never"
+        codex_config["model_reasoning_effort"] = effort
+        env["CODEX_CONFIG"] = json.dumps(codex_config)
     # hermes: no special env needed
     return env
 
@@ -638,7 +696,11 @@ class ACPNodeRunner:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=workspace_dir,
-            env=_acp_subprocess_env(role_config.worker_provider),
+            env=_acp_subprocess_env(
+                role_config.worker_provider,
+                role_config.worker_reasoning_effort,
+                acp_command,
+            ),
             limit=SUBPROCESS_STREAM_LIMIT,
         )
         progress_tracker = ACPProgressTracker(callback=progress_callback)
@@ -796,7 +858,11 @@ class ACPNodeRunner:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=workspace_dir,
-            env=_acp_subprocess_env(role_config.worker_provider),
+            env=_acp_subprocess_env(
+                role_config.worker_provider,
+                role_config.worker_reasoning_effort,
+                acp_command,
+            ),
             limit=SUBPROCESS_STREAM_LIMIT,
         )
         tracker = ACPProgressTracker(callback=progress_callback)

--- a/zenith/tests/test_acp_runner.py
+++ b/zenith/tests/test_acp_runner.py
@@ -20,6 +20,7 @@ from zenith_harness.acp_runner import (
     ACPNodeRunner,
     _acp_subprocess_env,
     _augment_acp_command,
+    _parse_codex_c_overrides,
 )
 from zenith_harness.providers import PROVIDERS
 from zenith_harness.assets import AssetLoader
@@ -188,6 +189,121 @@ def test_codex_acp_env_preserves_node_path_when_bwrap_is_present(
     assert str(bin_dir) in env["PATH"].split(os.pathsep)
     assert env["CODEX_SANDBOX"] == "danger-full-access"
     assert env["CODEX_DISABLE_SANDBOX"] == "1"
+
+
+def test_codex_acp_env_includes_codex_config_json_with_effort():
+    env = _acp_subprocess_env(PROVIDERS["codex"], reasoning_effort="max")
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["sandbox_mode"] == "danger-full-access"
+    assert config["approval_policy"] == "never"
+    assert config["model_reasoning_effort"] == "max"
+
+
+def test_codex_acp_env_codex_config_defaults_to_xhigh():
+    env = _acp_subprocess_env(PROVIDERS["codex"])
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["model_reasoning_effort"] == "xhigh"
+
+
+def test_codex_acp_env_merges_user_codex_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CODEX_CONFIG", json.dumps({"model": "gpt-5.6-luna"}))
+    env = _acp_subprocess_env(PROVIDERS["codex"], reasoning_effort="ultra")
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["model"] == "gpt-5.6-luna"
+    assert config["sandbox_mode"] == "danger-full-access"
+    assert config["approval_policy"] == "never"
+    assert config["model_reasoning_effort"] == "ultra"
+
+
+def test_codex_acp_env_overrides_user_safety_values(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(
+        "CODEX_CONFIG",
+        json.dumps({"sandbox_mode": "read-only", "approval_policy": "on-failure"}),
+    )
+    env = _acp_subprocess_env(PROVIDERS["codex"])
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["sandbox_mode"] == "danger-full-access"
+    assert config["approval_policy"] == "never"
+
+
+def test_codex_acp_env_invalid_user_codex_config_replaced(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CODEX_CONFIG", "not valid json")
+    env = _acp_subprocess_env(PROVIDERS["codex"], reasoning_effort="high")
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["sandbox_mode"] == "danger-full-access"
+    assert config["approval_policy"] == "never"
+    assert config["model_reasoning_effort"] == "high"
+
+
+def test_claude_acp_env_has_no_codex_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("CODEX_CONFIG", raising=False)
+    env = _acp_subprocess_env(PROVIDERS["claude"])
+    assert "CODEX_CONFIG" not in env
+
+
+def test_parse_codex_c_overrides_extracts_model():
+    cmd = 'codex-acp -c model="gpt-5.6-luna" -c sandbox_mode="danger-full-access"'
+    overrides = _parse_codex_c_overrides(cmd)
+    assert overrides["model"] == "gpt-5.6-luna"
+    assert overrides["sandbox_mode"] == "danger-full-access"
+
+
+def test_parse_codex_c_overrides_handles_single_quotes():
+    cmd = "codex-acp -c model='gpt-5.6-luna'"
+    overrides = _parse_codex_c_overrides(cmd)
+    assert overrides["model"] == "gpt-5.6-luna"
+
+
+def test_parse_codex_c_overrides_empty_when_no_flags():
+    assert _parse_codex_c_overrides("codex-acp") == {}
+
+
+def test_codex_acp_env_preserves_custom_model_from_command():
+    """The user's custom model from ZENITH_*_ACP_COMMAND's -c model=...
+    must reach CODEX_CONFIG — the npm adapter drops all argv -c flags."""
+    cmd = 'codex-acp -c model="gpt-5.6-luna" -c sandbox_mode="danger-full-access" -c approval_policy="never" -c model_reasoning_effort="max"'
+    env = _acp_subprocess_env(
+        PROVIDERS["codex"], reasoning_effort="max", acp_command=cmd
+    )
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["model"] == "gpt-5.6-luna"
+    assert config["sandbox_mode"] == "danger-full-access"
+    assert config["approval_policy"] == "never"
+    assert config["model_reasoning_effort"] == "max"
+
+
+def test_codex_acp_env_model_from_command_overrides_user_codex_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The -c model in the command string (explicit per-role) wins over
+    an ambient CODEX_CONFIG model."""
+    monkeypatch.setenv("CODEX_CONFIG", json.dumps({"model": "gpt-4o"}))
+    cmd = 'codex-acp -c model="gpt-5.6-luna"'
+    env = _acp_subprocess_env(
+        PROVIDERS["codex"], reasoning_effort="max", acp_command=cmd
+    )
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["model"] == "gpt-5.6-luna"
+
+
+def test_codex_acp_env_without_command_keeps_user_codex_config_model(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When no acp_command is passed, a user-supplied CODEX_CONFIG model
+    is preserved (backward-compatible call signature)."""
+    monkeypatch.setenv("CODEX_CONFIG", json.dumps({"model": "gpt-4o"}))
+    env = _acp_subprocess_env(PROVIDERS["codex"], reasoning_effort="high")
+    config = json.loads(env["CODEX_CONFIG"])
+    assert config["model"] == "gpt-4o"
+    assert config["model_reasoning_effort"] == "high"
 
 
 def test_attempt_path_naming(config: HarnessConfig, project_setup):


### PR DESCRIPTION
Fixes #27, and adds custom model override support (requested in the #27
comments, not part of the original issue).

## Problem (#27)
The npm `@agentclientprotocol/codex-acp` adapter (v1.1.0+, verified against
1.1.2) does not parse `-c` overrides from argv — it reads its startup
configuration from the `CODEX_CONFIG` env var (JSON), parsed at
`src/CodexAcpClient.ts` and spread unchanged into codex's `thread/start`
config. As a result, the `-c` flags appended by `_augment_acp_command`
(`sandbox_mode`, `approval_policy`, `model_reasoning_effort`) were silently
discarded — sandbox, approval policy, and reasoning effort never reached the
worker.

## Fix
Build `CODEX_CONFIG` in `_acp_subprocess_env` in three layers, each overriding
the previous:

1. User-supplied `CODEX_CONFIG` (ambient env).
2. `-c` overrides parsed from the augmented command string, via
   `_parse_codex_c_overrides` (handles both double- and single-quoted values).
3. Zenith's three safety keys (`sandbox_mode`, `approval_policy`,
   `model_reasoning_effort`) — always win, since sandbox/approval are
   autonomy-safety requirements and effort is the per-role resolved value.

The `-c` flags remain in argv for `-c`-honoring codex-acp builds (harmless if
ignored by the npm adapter). `_acp_subprocess_env` now accepts
`reasoning_effort` and `acp_command`; both call sites (`run_node`,
`run_terminal_review`) thread `role_config.worker_reasoning_effort` and the
augmented command through.

## Additional: custom model override
Routing all `-c` overrides through `CODEX_CONFIG` also lets a user-specified
codex model reach the adapter — previously dropped for the same reason. A
`model` supplied via `ZENITH_*_ACP_COMMAND` (`-c model="..."`) or ambient
`CODEX_CONFIG` is now preserved (layers 1–2) while zenith's safety keys still
override (layer 3). This is the model-override capability requested in the #27
comments; it is not part of the original issue but rides on the same mechanism.

## Verification
Verified end-to-end against the installed adapter: with a `CODEX_CONFIG`
carrying `model`, `sandbox_mode="danger-full-access"`,
`approval_policy="never"`, and `model_reasoning_effort="max"`, the adapter's
startup log (`app-server.log`) shows `codexConfig` with all four keys received.

## Tests
- `_parse_codex_c_overrides` extracts model + sandbox from double- and
  single-quoted `-c` flags; empty when no flags present.
- `CODEX_CONFIG` JSON present with correct effort; defaults to `xhigh`.
- User `CODEX_CONFIG` merged (preserves ambient model); command-string model
  wins over ambient model.
- Custom model from augmented command preserved alongside zenith's safety keys.
- Zenith's safety keys override user-supplied safety values; invalid user JSON
  replaced. Claude path has no `CODEX_CONFIG`.
