### PR TITLE
feat(prompts): treat orchestrator-authored digests as hypotheses, not evidence

### DIFF
--- a/zenith/src/zenith_harness/bundled/prompts/orchestrator/system_prompt.md
+++ b/zenith/src/zenith_harness/bundled/prompts/orchestrator/system_prompt.md
@@ -167,6 +167,8 @@ Keep durable guidance concise and curated. Do not paste transcripts, raw logs, o
 
 If a fact is only evidence for one verdict, leave it in the attempt, regression, or evidence artifact. If it changes how future work should be planned, executed, or validated, promote it into the appropriate durable carrier before more work depends on it.
 
+Investigation digests are hypotheses, not evidence. When you author a research or facts artifact from subagent reports, state each claim with the `file:line` or command output that supports it, and never introduce an absolute (only, every, never, all, sole) that a subagent did not explicitly verify — prefer the source's own wording over your paraphrase, because paraphrase sharpens hedged findings into confident claims that downstream agents treat as authoritative. Put a standing warning at the head of the file instructing readers to verify claims against source before use, and tell workers the digest is a starting map: on any disagreement, the source wins. When a worker corrects the digest, fold the correction in immediately and record it.
+
 ## Team, Skills, And Subagents
 
 Design the team method before dispatch. The orchestrator owns the mission model, scope interpretation, contract quality, task topology, team and skill design, attention decisions, source-of-truth propagation, replanning, and closure judgment. Workers implement assigned `work` tasks. Validators collect independent evidence for assigned `validate` tasks. Subagents gather bounded evidence or perform bounded review. None of them owns the mission decision.


### PR DESCRIPTION
## Summary

Adds a rule to the orchestrator prompt's Memory Folder section governing research/facts artifacts the orchestrator writes from subagent investigation reports.

In a real end-to-end Zenith mission (63 contract assertions, 18 tasks, ~7h wall clock), the orchestrator wrote a citation-backed source digest from parallel investigation subagents, and workers built the deliverable from it. Four of its factual claims were wrong, and three propagated onto the delivered artifact before the accuracy validation lane caught them. Every error was a manufactured absolute (*only, every, never, all*) that no subagent had verified — digest paraphrase sharpens hedged findings into confident claims, and downstream agents treat the digest as authoritative because it is citation-shaped.

No validation lane catches this by construction: content lanes judge whether a point is *explained*, and accuracy lanes audit the *deliverable* against source, not the intermediate digest. Since the runtime cannot structurally validate free text, the fix belongs in the prompt.

The added rule requires: (a) each digest claim backed by `file:line` or command output, (b) no absolutes a subagent did not explicitly verify — prefer the source's own wording over paraphrase, (c) a standing verify-before-use warning at the head of the file, source-wins on any disagreement, and immediate fold-in of worker corrections. In the mission above, workers *did* correct the digest twice unprompted where the project's AGENTS.md carried (c)-style guidance — that mechanism works; what was missing was the rule against manufacturing absolutes in the first place.

## Verification

- Prompt-only change; `uv run pytest` in `zenith/`: 240 passed, 7 skipped (suite as of this branch point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)