### PR TITLE
fix(terminal-review): stop injecting user-global context into the reviewer session

### DIFF
--- a/zenith/src/zenith_harness/acp_runner.py
+++ b/zenith/src/zenith_harness/acp_runner.py
@@ -118,6 +118,44 @@ def _augment_acp_command(
     return command
 
 
+def _terminal_reviewer_session_meta(provider) -> dict[str, Any] | None:
+    """Session `_meta` isolating the terminal reviewer from ambient context.
+
+    The terminal reviewer's system prompt declares the user request and the
+    workspace as its only inputs and forbids reading provider skill
+    directories. But `claude-agent-acp` defaults to
+    `settingSources: ["user", "project", "local"]` and leaves the SDK's
+    skill discovery on, so the user's global CLAUDE.md, settings.json, and
+    skill listings are injected into the reviewer's context before it reads
+    a single instruction — sources its own prompt forbids.
+
+    `_meta.claudeCode.options` is the adapter's documented pass-through
+    (`NewSessionMeta`); `settingSources`/`skills` are forwarded to the
+    Claude Agent SDK verbatim. Older adapters without the pass-through
+    ignore `_meta` — graceful degradation to current behavior.
+
+    Deliberately terminal-reviewer-only: workers and validators keep
+    ambient context, since global rules files are how users enforce
+    cross-project conventions. Independence is this role's requirement.
+    """
+    if getattr(provider, "name", None) != "claude":
+        return None
+    return {
+        "claudeCode": {
+            "options": {
+                # No user/project/local settings.json or CLAUDE.md. The
+                # adapter's own SettingsManager (permission mode, model
+                # resolution) reads settings unconditionally, so the
+                # _ensure_claude_settings workaround is unaffected.
+                "settingSources": [],
+                # Context filter, not a sandbox: skill files stay readable
+                # via Read/Bash, but the prompt already forbids that.
+                "skills": [],
+            }
+        }
+    }
+
+
 def _acp_subprocess_env(provider) -> dict[str, str]:
     """Build the env handed to an ACP-agent subprocess.
 
@@ -828,6 +866,9 @@ class ACPNodeRunner:
                 "mcpServers": [worker_mcp_cfg],
             }
             provider = role_config.worker_provider
+            session_meta = _terminal_reviewer_session_meta(provider)
+            if session_meta is not None:
+                session_params["_meta"] = session_meta
             session_resp = await client.send_request("session/new", session_params)
             session_id = session_resp["sessionId"]
             await self._maybe_set_mode(client, session_id, provider)

--- a/zenith/tests/mock_acp_agent.py
+++ b/zenith/tests/mock_acp_agent.py
@@ -14,7 +14,8 @@ Handles:
 Environment variables read from os.environ:
   ZENITH_HANDOFF_PATH  — where to write the synthesized handoff file
   ZENITH_NODE_ID       — node id to embed in handoff
-  ZENITH_NODE_TYPE     — work | validate (controls the handoff shape)
+  ZENITH_NODE_TYPE     — work | validate | terminal_review (handoff shape)
+  MOCK_ACP_SESSION_PARAMS_PATH — if set, dump session/new params here (JSON)
   ZENITH_VALIDATION_PASSED — '1' to mark items passed=true (validate only)
   MOCK_ACP_CRASH       — '1' to exit immediately without writing
   MOCK_ACP_REQUEST_ATTENTION — '1' to set request_attention=true
@@ -37,7 +38,12 @@ def _write_handoff() -> None:
     node_type = os.environ.get("ZENITH_NODE_TYPE", "work")
     done = os.environ.get("MOCK_ACP_DONE", "1") != "0"
     request_attention = os.environ.get("MOCK_ACP_REQUEST_ATTENTION") == "1"
-    if node_type == "validate":
+    if node_type == "terminal_review":
+        payload = {
+            "done": done,
+            "report": "mock terminal review",
+        }
+    elif node_type == "validate":
         passed = os.environ.get("ZENITH_VALIDATION_PASSED", "1") != "0"
         payload = {
             "node_id": node_id,
@@ -96,6 +102,11 @@ def main() -> None:
                 "authMethods": [],
             })
         elif method == "session/new":
+            params_path = os.environ.get("MOCK_ACP_SESSION_PARAMS_PATH")
+            if params_path:
+                Path(params_path).write_text(
+                    json.dumps(msg.get("params", {}), indent=2), encoding="utf-8"
+                )
             resp = _response(req_id, {"sessionId": "mock-session-1"})
         elif method == "session/set_mode":
             resp = _response(req_id, {})

--- a/zenith/tests/test_terminal_reviewer_isolation.py
+++ b/zenith/tests/test_terminal_reviewer_isolation.py
@@ -1,0 +1,135 @@
+"""Terminal reviewer ambient-context isolation tests.
+
+The terminal reviewer's system prompt declares the original user request
+and the workspace as its only inputs and forbids reading provider skill
+directories. These tests pin the runtime side of that contract: for the
+claude provider, `session/new` must carry `_meta.claudeCode.options`
+disabling filesystem setting sources and skill discovery, so the user's
+global CLAUDE.md / settings.json / skills are not injected into the
+reviewer's context by `claude-agent-acp` defaults.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from zenith_harness.acp_runner import (
+    ACPNodeRunner,
+    _terminal_reviewer_session_meta,
+)
+from zenith_harness.assets import AssetLoader
+from zenith_harness.config import HarnessConfig
+from zenith_harness.models import TerminalReviewHandoff
+from zenith_harness.providers import PROVIDERS
+from zenith_harness.storage import ProjectStore
+
+
+# ---------------------------------------------------------------------------
+# Unit: _terminal_reviewer_session_meta
+# ---------------------------------------------------------------------------
+
+
+def test_session_meta_claude_disables_setting_sources_and_skills():
+    meta = _terminal_reviewer_session_meta(PROVIDERS["claude"])
+    assert meta is not None
+    options = meta["claudeCode"]["options"]
+    assert options["settingSources"] == []
+    assert options["skills"] == []
+
+
+@pytest.mark.parametrize("provider_name", ["codex", "hermes"])
+def test_session_meta_non_claude_is_none(provider_name: str):
+    assert _terminal_reviewer_session_meta(PROVIDERS[provider_name]) is None
+
+
+# ---------------------------------------------------------------------------
+# Wiring: session/new carries the _meta through the real ACP client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_acp_command() -> str:
+    mock = Path(__file__).resolve().parent / "mock_acp_agent.py"
+    return f"{sys.executable} {mock}"
+
+
+@pytest.fixture
+def config(harness_home: Path, mock_acp_command: str) -> HarnessConfig:
+    bundled = Path(__file__).resolve().parents[1] / "src" / "zenith_harness" / "bundled"
+    return HarnessConfig(
+        bundled_dir=bundled,
+        harness_home=harness_home,
+        projects_dir=harness_home / "projects",
+        orchestrator_provider_name="claude",
+        worker_provider_name="claude",
+        worker_acp_command=mock_acp_command,
+        validator_provider_name=None,
+        validator_acp_command=None,
+        terminal_reviewer_provider_name=None,
+        # Explicit: the resolution chain prefers the provider's default
+        # command ("claude-agent-acp") over an inherited custom worker
+        # command, so leaving this None would spawn the real adapter.
+        terminal_reviewer_acp_command=mock_acp_command,
+    )
+
+
+def test_run_terminal_review_sends_isolation_meta(
+    config: HarnessConfig, workspace: Path, tmp_path: Path
+):
+    """End-to-end via the mock agent: the reviewer session must be opened
+    with settingSources/skills disabled, and the handoff must round-trip.
+    """
+    store = ProjectStore(config)
+    store.create_project("brief", workspace, project_id="p1")
+    spawn_ts = "2026-07-27T00-00-00Z"
+    report_path = store.terminal_review_path("p1", "mission-001", spawn_ts)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    params_path = tmp_path / "session_params.json"
+
+    os.environ["ZENITH_HANDOFF_PATH"] = str(report_path)
+    os.environ["ZENITH_NODE_TYPE"] = "terminal_review"
+    os.environ["MOCK_ACP_SESSION_PARAMS_PATH"] = str(params_path)
+    try:
+        runner = ACPNodeRunner(config=config, loader=AssetLoader(config))
+
+        async def _no_op_server(*args, **kwargs):
+            return await asyncio.create_subprocess_exec(
+                "sleep", "30",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+
+        async def _ready_immediately(*args, **kwargs):
+            return None
+
+        runner._start_terminal_reviewer_mcp = _no_op_server  # type: ignore[method-assign]
+        runner._wait_for_server_ready = _ready_immediately  # type: ignore[method-assign]
+
+        handoff = asyncio.run(
+            runner.run_terminal_review(
+                project_id="p1",
+                mission_id="mission-001",
+                spawn_ts=spawn_ts,
+                store=store,
+            )
+        )
+    finally:
+        for k in (
+            "ZENITH_HANDOFF_PATH",
+            "ZENITH_NODE_TYPE",
+            "MOCK_ACP_SESSION_PARAMS_PATH",
+        ):
+            os.environ.pop(k, None)
+
+    assert isinstance(handoff, TerminalReviewHandoff)
+    assert handoff.done is True
+
+    params = json.loads(params_path.read_text())
+    options = params["_meta"]["claudeCode"]["options"]
+    assert options["settingSources"] == []
+    assert options["skills"] == []


### PR DESCRIPTION
## Problem

The terminal reviewer's system prompt (`bundled/prompts/terminal-reviewer/system_prompt.md`) declares the original user request and the workspace as its **only inputs**, and its Forbidden Sources list explicitly bans `.claude/skills/`, provider subagent definitions, and `AGENTS.md` shims.

But the runtime violates its own spec: `claude-agent-acp` defaults to `settingSources: ["user", "project", "local"]` and leaves the Claude Agent SDK's skill discovery enabled. So every terminal-reviewer session gets the user's global `CLAUDE.md`, `settings.json` (including hooks), and skill listings injected into its context **before it reads a single instruction**. A prompt-level ban cannot un-read what the harness already injected — the reviewer's independence is currently prompt-deep only.

## Fix

Pass the adapter's documented `NewSessionMeta` pass-through on `session/new`, for the terminal reviewer only:

```python
"_meta": {"claudeCode": {"options": {"settingSources": [], "skills": []}}}
```

- `settingSources: []` — SDK isolation mode: no user/project/local `settings.json`, no `CLAUDE.md` files.
- `skills: []` — skills are a separate SDK option not governed by `settingSources`; empty list enables none. This is a context filter, not a sandbox (files stay on disk), but the prompt already forbids reading them — the filter closes the injection channel.

Gated to the claude provider; codex/hermes sessions are unchanged.

## Deliberately narrow

Workers and validators are **not** touched. Global rules files are how users enforce cross-project conventions, and the validator prompt already establishes the source hierarchy (contract defines the evidence floor; skills provide method only). Independence is uniquely the terminal reviewer's requirement.

## Non-interactions verified

- `_ensure_claude_settings` (the `defaultMode: auto` workaround) is unaffected: the adapter's own `SettingsManager` loads settings unconditionally from `params.cwd` and only feeds permission-mode/model resolution — a separate path from the SDK's `settingSources`.
- Older adapter versions without the `_meta.claudeCode.options` pass-through ignore `_meta` entirely — graceful degradation to current behavior.

## Consequence worth naming

`settingSources: []` also drops the user-global `CLAUDE.md`, which the Forbidden Sources list doesn't name literally — but the prompt's closed "your only inputs are" list covers it, and `settingSources` has no finer granularity (`"user"` is all-or-nothing).

## Tests

- Unit: `_terminal_reviewer_session_meta` returns the isolation options for claude, `None` for codex/hermes.
- Wiring: `run_terminal_review` end-to-end via the mock ACP agent, asserting `session/new` carries the `_meta` and the handoff round-trips. `mock_acp_agent.py` grows `MOCK_ACP_SESSION_PARAMS_PATH` (dump `session/new` params) and a `terminal_review` handoff shape — both additive.

`uv run pytest`: 216 passed, 7 skipped (the pre-existing real-agent smoke skips) on top of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
