### PR TITLE
fix(cli): escape env values in the codex config.toml writer

### DIFF
--- a/zenith/src/zenith_harness/cli.py
+++ b/zenith/src/zenith_harness/cli.py
@@ -397,7 +397,11 @@ def _write_bootstrap_config(
     elif fmt == "codex_config":
         config_path = workspace / ".codex" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        env_lines = "\n".join(f'{k} = "{v}"' for k, v in env.items())
+        # TOML basic strings share JSON's escape syntax, so json.dumps closes
+        # and escapes embedded quotes. ACP commands splice config via
+        # `-c key="value"`, and forwarded env values may hold quotes or
+        # backslashes; interpolating either raw emits invalid TOML.
+        env_lines = "\n".join(f"{k} = {json.dumps(v)}" for k, v in env.items())
         block = (
             'model = "gpt-5.5"\n'
             'sandbox_mode = "danger-full-access"\n'

--- a/zenith/tests/test_cli.py
+++ b/zenith/tests/test_cli.py
@@ -141,6 +141,45 @@ class TestInit:
         assert server_env["ZENITH_VALIDATOR_REASONING_EFFORT"] == "medium"
         assert server_env["ZENITH_TERMINAL_REVIEWER_REASONING_EFFORT"] == "low"
 
+    def test_codex_init_escapes_quoted_acp_commands(
+        self, runner: CliRunner, workspace: Path, env: dict[str, str]
+    ) -> None:
+        """Quoted ACP commands must survive into config.toml as valid TOML.
+
+        `-c key="value"` is the supported splice shape for codex config, so
+        a role's command can carry double quotes. Interpolating them raw
+        terminates the TOML string early and corrupts the managed block.
+        The two commands differ so `ProviderSelection.env()` emits both —
+        it suppresses a role whose resolved command matches the previous
+        role's.
+        """
+        worker_cmd = 'codex-acp -c model="gpt-5.6-luna"'
+        validator_cmd = 'codex-acp -c model="gpt-5.6-terra"'
+
+        r = runner.invoke(
+            cli,
+            [
+                "init",
+                "--workspace-dir",
+                str(workspace),
+                "--agent",
+                "codex",
+                "--worker-acp-command",
+                worker_cmd,
+                "--validator-acp-command",
+                validator_cmd,
+            ],
+        )
+        assert r.exit_code == 0, r.output
+
+        # Parsing at all is the regression guard — this raises before the fix.
+        config = tomllib.loads(
+            (workspace / ".codex" / "config.toml").read_text(encoding="utf-8")
+        )
+        server_env = config["mcp_servers"]["zenith"]["env"]
+        assert server_env["ZENITH_WORKER_ACP_COMMAND"] == worker_cmd
+        assert server_env["ZENITH_VALIDATOR_ACP_COMMAND"] == validator_cmd
+
     def test_init_reasoning_effort_flags_override_env(
         self,
         runner: CliRunner,


### PR DESCRIPTION
## Problem

`zenith init --agent codex` writes `[mcp_servers.zenith.env]` into
`.codex/config.toml` by interpolating each value into a TOML basic string
with a raw f-string ([`cli.py`][l], no escaping of `"`, `\`, or newlines):

```python
env_lines = "\n".join(f'{k} = "{v}"' for k, v in env.items())
```

`-c key="value"` is the supported way to splice codex config through
`ZENITH_*_ACP_COMMAND`, so those values routinely contain double quotes:

```console
$ zenith init --agent codex \
    --validator-acp-command 'codex-acp -c model="gpt-5.6-terra"'
```

emits invalid TOML — the string terminates at `model=`, leaving a dangling
`gpt-5.6-terra""`:

```toml
ZENITH_VALIDATOR_ACP_COMMAND = "codex-acp -c model="gpt-5.6-terra""
```

Codex then fails to parse `config.toml` or drops the whole managed block, and
the role silently falls back to defaults. Because the line loops over the
entire env dict, the same hole affects every role's ACP command and any
forwarded allowlisted value (`ANTHROPIC_MODEL`, `ZAI_API_KEY`, base URLs)
that contains a quote or backslash.

## Fix

Serialize with `json.dumps`. TOML basic strings share JSON's escape syntax,
and `json.dumps` emits only escapes TOML accepts (`\"`, `\\`, `\n`, `\t`,
`\uXXXX`; never `\/` by default). This mirrors the
`args = {json.dumps(server_args)}` line directly below it, and fixes every
role at once since the loop spans the whole env dict. Env var names are valid
TOML bare keys, so keys are unchanged.

Only the `codex_config` branch was affected — the `mcp_json` branch hands the
same env dict to `json.dumps` and has always been correct.

## Why this surfaced now

Related: #31. Before that change, a custom `-c model="..."` inside
`ZENITH_*_ACP_COMMAND` was silently discarded by the npm `codex-acp` adapter,
so there was little reason to pass a quoted `-c` value to
`--worker-acp-command`. #31 makes those overrides functional by routing them
through `CODEX_CONFIG`, which turns this latent escaping hole into reachable
config corruption.

**This PR has no code dependency on #31.** It applies cleanly to `main` as-is,
does not touch `acp_runner.py`, and can merge before, after, or independently
of that PR. (`_augment_acp_command` has always appended
`-c sandbox_mode="danger-full-access"`, but that happens at dispatch and never
reaches `config.toml`; only user-supplied commands are written by
`zenith init`.)

## Testing

New `test_codex_init_escapes_quoted_acp_commands` drives `zenith init --agent
codex` with a distinct quoted command for worker and validator, asserts
`config.toml` parses via `tomllib`, and asserts each value round-trips
byte-identical. It raises `TOMLDecodeError` without the fix.

Existing codex config tests are unaffected — `json.dumps` on quote-free values
produces byte-identical output to the current code.

- [x] `uv run pytest -q` — 213 passed, 7 skipped
- [x] `uv run ruff check .` — passed
- [x] `uv run mypy src` — passed
- [x] Verified end-to-end: before the fix `tomllib.loads` on the generated
      `config.toml` raises; after, all commands parse with quotes intact.

[l]: https://github.com/Intelligent-Internet/zenith/blob/main/zenith/src/zenith_harness/cli.py#L400

🤖 Generated with [Claude Code](https://claude.com/claude-code)